### PR TITLE
Default tenant schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Steps to run TestProcess1
 1. Log in as admin username: `admin`, password: `admin`
 1. Select Tasklist from the Dashboard
 1. In top right corner click "Start process", select "TestProcess1", click "start"
-1. Refresh Tasklist page or click "My Tasks" and you should see a new task generated
+1. Refresh Tasklist page or click "All Tasks" and you should see a new task generated
 1. Select "Task1" and click "Claim" in top right corner of task form
     1. Task should have two variable fields pre-populated. You can change these if you would like
     1. Task has boolean option "Throw Error?" to check if you want to generate the error handling task

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Steps to run TestProcess1
 
 1. Run the application `mvn clean spring-boot:run`
 1. Navigate to Camunda Portal `localhost:9000/app/welcome/default/#/welcome`
-1. Log in as admin username: `bboring`, password: `password`
+1. Log in as admin username: `admin`, password: `admin`
 1. Select Tasklist from the Dashboard
 1. In top right corner click "Start process", select "TestProcess1", click "start"
 1. Refresh Tasklist page or click "My Tasks" and you should see a new task generated

--- a/pom.xml
+++ b/pom.xml
@@ -156,12 +156,6 @@
       <version>${camunda.spring.boot.version}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <optional>true</optional>
-    </dependency>
-
   </dependencies>
 
   <distributionManagement>

--- a/src/main/java/org/folio/rest/delegate/System1Delegate.java
+++ b/src/main/java/org/folio/rest/delegate/System1Delegate.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class System1Delegate implements JavaDelegate {
 
-  private final static Logger log = LoggerFactory.getLogger(System1Delegate.class);
+  private static final Logger log = LoggerFactory.getLogger(System1Delegate.class);
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
@@ -19,9 +19,17 @@ public class System1Delegate implements JavaDelegate {
     String instanceId = execution.getProcessInstanceId();
     String definitionId = execution.getProcessDefinitionId();
 
-    RepositoryService repositoryService = execution.getProcessEngineServices().getRepositoryService();
-    String processName = repositoryService.createProcessDefinitionQuery().processDefinitionId(definitionId)
-        .singleResult().getName();
+    // @formatter:off
+    RepositoryService repositoryService = execution
+        .getProcessEngineServices()
+        .getRepositoryService();
+    
+    String processName = repositoryService
+        .createProcessDefinitionQuery()
+        .processDefinitionId(definitionId)
+        .singleResult()
+        .getName();
+    // @formatter:on
 
     log.info("Process: {}, Instance: {}", processName, instanceId);
 

--- a/src/main/java/org/folio/rest/delegate/System1Delegate.java
+++ b/src/main/java/org/folio/rest/delegate/System1Delegate.java
@@ -1,14 +1,16 @@
 package org.folio.rest.delegate;
 
-import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.RepositoryService;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 @Service
-@Slf4j
 public class System1Delegate implements JavaDelegate {
+
+  private final static Logger log = LoggerFactory.getLogger(System1Delegate.class);
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
@@ -18,13 +20,12 @@ public class System1Delegate implements JavaDelegate {
     String definitionId = execution.getProcessDefinitionId();
 
     RepositoryService repositoryService = execution.getProcessEngineServices().getRepositoryService();
-    String processName = repositoryService.createProcessDefinitionQuery()
-      .processDefinitionId(definitionId)
-      .singleResult()
-      .getName();
+    String processName = repositoryService.createProcessDefinitionQuery().processDefinitionId(definitionId)
+        .singleResult().getName();
 
     log.info("Process: {}, Instance: {}", processName, instanceId);
 
     execution.setVariable("delegateVariable", "SampleStringVariable");
   }
+
 }

--- a/src/main/java/org/folio/rest/delegate/ThrowRuntimeErrorDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/ThrowRuntimeErrorDelegate.java
@@ -1,17 +1,18 @@
 package org.folio.rest.delegate;
 
-import lombok.extern.slf4j.Slf4j;
-import org.camunda.bpm.engine.RepositoryService;
+import java.util.ArrayList;
+
 import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-
 @Service
-@Slf4j
 public class ThrowRuntimeErrorDelegate implements JavaDelegate {
+
+  private final static Logger log = LoggerFactory.getLogger(System1Delegate.class);
 
   @Override
   public void execute(DelegateExecution execution) {
@@ -25,4 +26,5 @@ public class ThrowRuntimeErrorDelegate implements JavaDelegate {
       throw new BpmnError("RUNTIME_ERROR", message);
     }
   }
+
 }

--- a/src/main/java/org/folio/rest/delegate/ThrowRuntimeErrorDelegate.java
+++ b/src/main/java/org/folio/rest/delegate/ThrowRuntimeErrorDelegate.java
@@ -1,7 +1,5 @@
 package org.folio.rest.delegate;
 
-import java.util.ArrayList;
-
 import org.camunda.bpm.engine.delegate.BpmnError;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
@@ -12,15 +10,13 @@ import org.springframework.stereotype.Service;
 @Service
 public class ThrowRuntimeErrorDelegate implements JavaDelegate {
 
-  private final static Logger log = LoggerFactory.getLogger(System1Delegate.class);
+  private static final Logger log = LoggerFactory.getLogger(System1Delegate.class);
 
   @Override
   public void execute(DelegateExecution execution) {
     try {
       log.info("Throwing runtime error...");
-
-      ArrayList arr = new ArrayList<>();
-      arr.get(1);
+      throw new RuntimeException("This is an example exception!");
     } catch (Exception e) {
       String message = e.getMessage();
       throw new BpmnError("RUNTIME_ERROR", message);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ logging:
   path:
 
 server:
-  port: 9000
+  port: 9001
 
 spring:
   data.rest:
@@ -34,8 +34,9 @@ spring:
     # database-platform: org.hibernate.dialect.PostgreSQLDialect
 
     properties.hibernate.jdbc.lob.non_contextual_creation: true
-    generate-ddl: true
-    hibernate.ddl-auto: create-drop
+    generate-ddl: false
+    hibernate.ddl-auto: none
+    initialization: false
     open-in-view: true
     show-sql: false
   profiles:
@@ -48,14 +49,16 @@ camunda:
   bpm:
     filter.create: My Tasks
     admin-user:
-      id: bboring
-      password: password
-      first-name: Bob
-      last-name: Boring
-      email: bboring@mailinator.com
+      id: admin
+      password: admin
+      first-name: Camunda
+      last-name: Admin
+      email: admin@mailinator.com
       # authorization.enabled: true
 
-additional:
+tenant:
+  header-name: X-Okapi-Tenant
+  force-tenant: false
   domain-packages:
   # https://github.com/camunda/camunda-bpm-platform/tree/master/engine/src/main/resources/org/camunda/bpm/engine/db/create
   # be sure to match datasource platform

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ logging:
   path:
 
 server:
-  port: 9001
+  port: 9000
 
 spring:
   application.name: mod-camunda

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,6 +12,7 @@ server:
   port: 9001
 
 spring:
+  application.name: mod-camunda
   data.rest:
     returnBodyOnCreate: true
     returnBodyOnUpdate: true
@@ -47,7 +48,10 @@ spring:
 
 camunda:
   bpm:
-    filter.create: My Tasks
+    database:
+      schema-update: false
+    filter:
+      create: All Tasks
     admin-user:
       id: admin
       password: admin
@@ -59,6 +63,8 @@ camunda:
 tenant:
   header-name: X-Okapi-Tenant
   force-tenant: false
+  default-tenant: public
+  initialize-default-tenant: true
   domain-packages:
   # https://github.com/camunda/camunda-bpm-platform/tree/master/engine/src/main/resources/org/camunda/bpm/engine/db/create
   # be sure to match datasource platform

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -28,8 +28,9 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect
     properties.hibernate.jdbc.lob.non_contextual_creation: true
-    generate-ddl: true
-    hibernate.ddl-auto: create-drop
+    generate-ddl: false
+    hibernate.ddl-auto: none
+    initialization: false
     open-in-view: true
     show-sql: false
   profiles:
@@ -38,8 +39,23 @@ spring:
     mode: TEXT
     suffix: .sql
 
-additional:
+camunda:
+  bpm:
+    filter.create: My Tasks
+    admin-user:
+      id: admin
+      password: admin
+      first-name: Camunda
+      last-name: Admin
+      email: admin@mailinator.com
+      # authorization.enabled: true
+
+tenant:
+  header-name: X-Okapi-Tenant
+  force-tenant: false
   domain-packages:
+  # https://github.com/camunda/camunda-bpm-platform/tree/master/engine/src/main/resources/org/camunda/bpm/engine/db/create
+  # be sure to match datasource platform
   schema-scripts:
     - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.engine.sql
     - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.history.sql

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,7 @@ server:
   port: 9100
 
 spring:
+  application.name: mod-camunda
   data.rest:
     returnBodyOnCreate: true
     returnBodyOnUpdate: true
@@ -41,7 +42,10 @@ spring:
 
 camunda:
   bpm:
-    filter.create: My Tasks
+    database:
+      schema-update: false
+    filter:
+      create: All Tasks
     admin-user:
       id: admin
       password: admin
@@ -53,6 +57,8 @@ camunda:
 tenant:
   header-name: X-Okapi-Tenant
   force-tenant: false
+  default-tenant: public
+  initialize-default-tenant: true
   domain-packages:
   # https://github.com/camunda/camunda-bpm-platform/tree/master/engine/src/main/resources/org/camunda/bpm/engine/db/create
   # be sure to match datasource platform


### PR DESCRIPTION
- use latest spring-module-core tenant configuration
- disable camunda-bpm-spring-boot-starter from creating a schema
- create process engine schema for default tenant, 'public'
- update user information, a bit more appropriate
- removed lombok, may consider later if end up with a lot of boiler plate code


We will inevitably be versioning spring-module-core, but for now everything is still new and happens to still be reverse compatible.  