### PR TITLE
aspect to inject tenant for schema selection during delegate execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Steps to run TestProcess1
 
 1. Run the application `mvn clean spring-boot:run`
 2. Register 'TestProcess1' using REST API
-    1. ```curl -X POST -H "X-Okapi-Tenant: tamu" -F "deployment-name=TestProcess1" -F "deployment-source=process application"  -F "data=@src/main/resources/workflows/TestProcess1.bpmn" http://localhost:9000/camunda/deployment/create```
+    1. ```curl -X POST -H "X-Okapi-Tenant: tamu" -F "tenant-id=tamu" -F "deployment-name=TestProcess1" -F "deployment-source=process application" -F "data=@src/main/resources/workflows/TestProcess1.bpmn" http://localhost:9000/camunda/deployment/create```
 3. Navigate to Camunda Portal `localhost:9000/app/welcome/default/#/welcome`
 4. Log in as admin username: `admin`, password: `admin`
 5. Select Tasklist from the Dashboard

--- a/src/main/java/org/folio/rest/aspect/TenantInjectionDelegateAspect.java
+++ b/src/main/java/org/folio/rest/aspect/TenantInjectionDelegateAspect.java
@@ -1,0 +1,32 @@
+package org.folio.rest.aspect;
+
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.folio.rest.tenant.config.TenantConfig;
+import org.folio.rest.tenant.exception.NoTenantException;
+import org.folio.rest.tenant.storage.ThreadLocalStorage;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class TenantInjectionDelegateAspect {
+
+  @Autowired
+  private TenantConfig tenantConfig;
+
+  @Before("execution(* org.camunda.bpm.engine.delegate.JavaDelegate.execute (org.camunda.bpm.engine.delegate.DelegateExecution)) && args(execution)")
+  public void beforeDelegateExecution(DelegateExecution execution) {
+    String tenant = execution.getTenantId();
+    if (tenant == null) {
+      // NOTE: force tenant is also used to enforce HTTP requests to contain tenant header
+      if (tenantConfig.isForceTenant()) {
+        throw new NoTenantException("No tenant found in thread safe tenant storage!");
+      }
+      tenant = tenantConfig.getDefaultTenant();
+    }
+    ThreadLocalStorage.setTenant(tenant);
+  }
+
+}


### PR DESCRIPTION
- every delegate will inject tenant into thread safe storage for schema identification
- expects deployment/process to be created with a tenant specified

to improve upon this the create of deployment/process can be intercepted and set the form-data tenant-id from the tenant header, but for now we can just add it to the form data

this has been tested with multiple tenants within Okapi

uses latest commit to spring-module-core, https://github.com/folio-org/spring-module-core/commit/40db15effd470bfc27116a73c6838cfec5a8c817, which is reverse compatible