### PR TITLE
update module descriptor

### DIFF
--- a/src/main/resources/descriptors/ModuleDescriptor.json
+++ b/src/main/resources/descriptors/ModuleDescriptor.json
@@ -1,6 +1,6 @@
 {
   "id": "@project.artifactId@-@project.version@",
-  "name": "Workflow Module",
+  "name": "Camnuda BPM Module",
   "provides": [
     {
       "id": "process",
@@ -335,6 +335,12 @@
         "message.domain.all"
       ],
       "visible": false
+    }
+  ],
+  "requires": [
+    {
+      "id": "actions",
+      "version": "1.0"
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
Actions is currently the only interface exposed by mod-workflow. Making this interface required will ensure mod-workflow is deployed to Okapi for the same tenant. This will assist with the hard dependency of mod-camunda requiring mod-workflows temp ActiveMQ broker.