### PR TITLE
FOLIO-3565: openjdk image: apt-get upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,12 @@ RUN mvn package
 # final base image
 FROM openjdk:11-jre-slim
 
+# Upgrade to latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
 # set deployment directory
 WORKDIR /mod-camunda
 


### PR DESCRIPTION
The Dockerfile uses

`FROM openjdk:11-jre-slim`

as base image. Run apt-get upgrade to upgrade vulnerable packages. This will fix these vulnerabilities:

* zlib/zlib1g Out-of-bounds Write https://nvd.nist.gov/vuln/detail/CVE-2022-37434
* gnutls28/libgnutls30 Double Free https://nvd.nist.gov/vuln/detail/CVE-2022-2509