### PR TITLE
FOLIO-3614: Remove unused commons-text 1.8 dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -266,12 +266,6 @@
 
     <dependency>
       <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.8</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
 


### PR DESCRIPTION
mod-camunda has a commons-text 1.8 maven dependency https://github.com/folio-org/mod-camunda/blob/c1eb47de77a31a9f45bc0a7205e1485b7619a9c1/pom.xml#L267-L271

However, it is not used, and all commons-text versions below 1.10.0 have a Remote Execution vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Task: Remove the unused commons-text dependency to avoid false positive security warning from Snyk and other vulnerability scanners.