### PR TITLE
MODCAMUNDA-1: Address problems discovered while testing and reviewing the latest changes.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
@@ -79,9 +79,9 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
     String to = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailTo"), inputs);
     String from = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailFrom"), inputs);
 
-    Optional<String> cc = Objects.nonNull(this.mailCc) ? Optional.of(this.mailCc.getValue(execution).toString()) : Optional.empty();
-    Optional<String> bcc = Objects.nonNull(this.mailBcc) ? Optional.of(this.mailBcc.getValue(execution).toString()) : Optional.empty();
-    Optional<String> attachmentPath = Objects.nonNull(this.attachmentPath) ? Optional.of(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("attachmentPath"), inputs)) : Optional.empty();
+    Optional<String> cc = Objects.nonNull(this.mailCc) ? Optional.ofNullable(this.mailCc.getValue(execution).toString()) : Optional.empty();
+    Optional<String> bcc = Objects.nonNull(this.mailBcc) ? Optional.ofNullable(this.mailBcc.getValue(execution).toString()) : Optional.empty();
+    Optional<String> attachmentPath = Objects.nonNull(this.attachmentPath) ? Optional.ofNullable(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("attachmentPath"), inputs)) : Optional.empty();
 
     MimeMessagePreparator preparator = new MimeMessagePreparator() {
       public void prepare(MimeMessage mimeMessage) throws Exception {

--- a/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
@@ -57,11 +57,11 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
     int port = Integer.parseInt(this.port.getValue(execution).toString());
 
     Optional<String> username = Objects.nonNull(this.username)
-      ? Optional.of(this.username.getValue(execution).toString())
+      ? Optional.ofNullable(this.username.getValue(execution).toString())
       : Optional.empty();
 
     Optional<String> password = Objects.nonNull(this.password)
-      ? Optional.of(this.password.getValue(execution).toString())
+      ? Optional.ofNullable(this.password.getValue(execution).toString())
       : Optional.empty();
 
     FileSystemManager manager = VFS.getManager();
@@ -125,7 +125,7 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
         break;
     }
 
-    
+
 
     long endTime = System.nanoTime();
     getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);

--- a/src/main/java/org/folio/rest/camunda/delegate/Input.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/Input.java
@@ -28,9 +28,9 @@ public interface Input {
   public default Map<String, Object> getInputs(DelegateExecution execution) throws JsonProcessingException {
     Map<String, Object> inputs = new HashMap<String, Object>();
     for (EmbeddedVariable variable : getInputVariables(execution)) {
-      Optional<String> key = Optional.of(variable.getKey());
+      Optional<String> key = Optional.ofNullable(variable.getKey());
       if (key.isPresent()) {
-        Optional<VariableType> type = Optional.of(variable.getType());
+        Optional<VariableType> type = Optional.ofNullable(variable.getType());
         if (type.isPresent()) {
           Optional<Object> value = Optional.empty();
           switch (type.get()) {

--- a/src/main/java/org/folio/rest/camunda/delegate/Output.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/Output.java
@@ -25,10 +25,10 @@ public interface Output {
 
   public default void setOutput(DelegateExecution execution, Object output) throws JsonProcessingException {
     EmbeddedVariable variable = getOutputVariable(execution);
-    Optional<String> key = Optional.of(variable.getKey());
+    Optional<String> key = Optional.ofNullable(variable.getKey());
     if (key.isPresent()) {
       if (Objects.nonNull(output)) {
-        Optional<VariableType> type = Optional.of(variable.getType());
+        Optional<VariableType> type = Optional.ofNullable(variable.getType());
         Object value = variable.isSpin()
           ? JSON(getObjectMapper().writeValueAsString(output))
           : Variables.objectValue(output, variable.getAsTransient()).create();

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -94,11 +94,11 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
     setOutput(execution, response.getBody());
 
     getHeaderOutputVariables(execution).forEach(headerOutputVariable -> {
-      Optional<String> key = Optional.of(headerOutputVariable.getKey());
+      Optional<String> key = Optional.ofNullable(headerOutputVariable.getKey());
       if (key.isPresent()) {
         Optional<String> headerOutput = Optional.ofNullable(response.getHeaders().getFirst(key.get()));
         if (headerOutput.isPresent()) {
-          Optional<VariableType> type = Optional.of(headerOutputVariable.getType());
+          Optional<VariableType> type = Optional.ofNullable(headerOutputVariable.getType());
           if (type.isPresent()) {
             switch (type.get()) {
             case LOCAL:

--- a/src/main/java/org/folio/rest/camunda/service/ScriptEngineService.java
+++ b/src/main/java/org/folio/rest/camunda/service/ScriptEngineService.java
@@ -89,7 +89,7 @@ public class ScriptEngineService {
         newEngine.eval(loadScript(UTILS_PREFIX + extension));
       }
 
-      maybeScriptEngine = Optional.of(newEngine);
+      maybeScriptEngine = Optional.ofNullable(newEngine);
     }
 
     ScriptEngine scriptEngine = maybeScriptEngine.get();

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,6 +84,7 @@ spring:
     properties.mail.smtp:
       auth: false
       starttls.enable: true
+      ssl.checkserveridentity: true
     protocol: smtp
     test-connection: false
 


### PR DESCRIPTION
Add `spring.mail.properties.mail.smtp.ssl.checkserveridentity` property.

Set the default to `true` for security.
Different environments may want to override this.
This can be done by changing the boolean to `false` or setting this environment variable like so:
```
SPRING_MAIL_PROPERTIES_MAIL_SMTP_SSL_CHECKSERVERIDENTITY=false
```

or disable SSL/TLS entirely:
```
SPRING_MAIL_PROPERTIES_MAIL_SMTP_STARTTLS_ENABLE=false
```

Change `Optional.of()` to `Optional.ofNullable()` to prevent NPEs.