### PR TITLE
MODCAMUNDA-1: BMP related changes, removing dead code and fixing log messages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <spring-module-core.version>2.1.0-SNAPSHOT</spring-module-core.version>
     <workflow-components.version>1.2.0-SNAPSHOT</workflow-components.version>
     <camunda.version>7.21.0-alpha2</camunda.version>
-    <camunda.spring.boot.version>7.21.0-alpha2</camunda.spring.boot.version>
     <openapi.server.port>9000</openapi.server.port>
   </properties>
 
@@ -238,13 +237,13 @@
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js</artifactId>
-      <version>22.3.3</version>
+      <version>23.0.3</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
-      <version>22.3.3</version>
+      <version>23.1.2</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
@@ -1,13 +1,19 @@
 package org.folio.rest.camunda.delegate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
-@Slf4j
 public abstract class AbstractDelegate implements JavaDelegate {
+
+  private final Logger log;
+
+  AbstractDelegate() {
+    // The logger is non-static to ensure that the implementing class name is used for the logger.
+    log = LoggerFactory.getLogger(this.getClass());
+  }
 
   @Autowired
   protected ObjectMapper objectMapper;

--- a/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
+++ b/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
@@ -163,7 +163,7 @@ public class BpmnModelFactory {
             builder = ((StartEventBuilder) builder).interrupting(interrupting);
             break;
           default:
-            // unknown start event
+            logger.warn("Start Event named {} is has an unknown event type of {}.", node.getName(), type);
             break;
           }
 
@@ -183,6 +183,7 @@ public class BpmnModelFactory {
             case NONE:
             case SIMPLE:
             default:
+              logger.warn("Start Event named {} is has an unknown setup type of {}.", node.getName(), setup);
               break;
             }
           }
@@ -190,7 +191,7 @@ public class BpmnModelFactory {
         } else if (node instanceof EndEvent) {
           builder = builder.endEvent(node.getIdentifier()).name(node.getName());
         } else {
-          // unknown event
+          logger.warn("Event named {} is of an unknown type.", node.getName());
         }
 
       } else if (node instanceof DelegateTask) {
@@ -291,6 +292,7 @@ public class BpmnModelFactory {
             // TODO: create custom exception and controller advice to handle better
             throw new RuntimeException("Transaction subprocess not yet supported!");
           default:
+            logger.warn("Subprocess named {} is of an unknown type.", node.getName());
             break;
           }
 
@@ -310,7 +312,7 @@ public class BpmnModelFactory {
           builder = builder.connectTo(((ConnectTo) node).getNodeId());
 
         } else {
-          // unknown navigation
+          logger.warn("Navigation named {} is of an unknown type.", node.getName());
         }
 
       } else if (node instanceof Task) {
@@ -319,7 +321,7 @@ public class BpmnModelFactory {
             builder = builder.receiveTask(node.getIdentifier()).name(node.getName())
                 .message(((ReceiveTask) node).getMessage());
           } else {
-            // unknown wait
+            logger.warn("Wait Task named {} is of an unknown type.", node.getName());
           }
         } else if (node instanceof ScriptTask) {
           builder = builder.scriptTask(node.getIdentifier()).name(node.getName())
@@ -330,7 +332,7 @@ public class BpmnModelFactory {
           }
 
         } else {
-          // unknown task
+          logger.warn("Script Task named {} is of an unknown type.", node.getName());
         }
 
         if (((Task) node).isAsyncBefore()) {
@@ -429,6 +431,9 @@ public class BpmnModelFactory {
         scripts.addAll(getProcessorScripts(((Branch) node).getNodes()));
       } else if (node instanceof Subprocess) {
         scripts.addAll(getProcessorScripts(((Subprocess) node).getNodes()));
+      }
+      else {
+        logger.warn("Processor Script named {} is of an unknown type.", node.getName());
       }
     });
     return scripts;

--- a/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
+++ b/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
@@ -163,7 +163,7 @@ public class BpmnModelFactory {
             builder = ((StartEventBuilder) builder).interrupting(interrupting);
             break;
           default:
-            logger.warn("Start Event named {} is has an unknown event type of {}.", node.getName(), type);
+            logger.warn("Start Event named {} has an unknown event type of {}.", node.getName(), type);
             break;
           }
 
@@ -183,7 +183,7 @@ public class BpmnModelFactory {
             case NONE:
             case SIMPLE:
             default:
-              logger.warn("Start Event named {} is has an unknown setup type of {}.", node.getName(), setup);
+              logger.warn("Start Event named {} has an unknown setup type of {}.", node.getName(), setup);
               break;
             }
           }

--- a/src/main/resources/META-INF/bpm-platform.xml
+++ b/src/main/resources/META-INF/bpm-platform.xml
@@ -1,9 +1,0 @@
-<job-executor>
-  <job-acquisition name="default">
-    <properties>
-      <property name="waitTimeInMillis">15000</property>
-      <property name="lockTimeInMillis">900000</property>
-      <property name="javascriptScriptEngine">Graal.js</property>
-    </properties>
-  </job-acquisition>
-</job-executor>

--- a/src/main/resources/application-test.yaml
+++ b/src/main/resources/application-test.yaml
@@ -90,6 +90,7 @@ spring:
   jersey.application-path: rest
 
 camunda:
+  # see: https://docs.camunda.org/manual/7.20/user-guide/spring-boot-integration/configuration/
   bpm:
     auto-deployment-enabled: false
     database:
@@ -105,7 +106,27 @@ camunda:
     # authorization.enabled: true
     default-number-of-retries: 1
     job-execution:
+      enabled: true
+      backoff-decrease-threshold: 100
+      backoff-time-in-millis: 0
+      core-pool-size: 3
+      deployment-aware: false
+      keep-alive-seconds: 0
       lock-time-in-millis: 3600000
+      max-backoff: 0
+      max-jobs-per-acquisition: 3
+      max-pool-size: 10
+      max-wait: 60000
+      queue-capacity: 3
+      wait-increase-factor: 2
+      wait-time-in-millis: 15000
+    # see: https://docs.camunda.org/manual/7.20/user-guide/spring-boot-integration/configuration/#generic-properties 
+    generic-properties:
+      properties:
+        telemetry-reporter-activate: false
+        enable-script-compilation: true
+        enable-script-engine-nashorn-compatibility: true
+        enable-fetch-script-engine-from-process-application: false
 
 springdoc:
   api-docs:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -98,6 +98,7 @@ spring:
   jersey.application-path: rest
 
 camunda:
+  # see: https://docs.camunda.org/manual/7.20/user-guide/spring-boot-integration/configuration/
   bpm:
     auto-deployment-enabled: false
     database:
@@ -113,7 +114,27 @@ camunda:
     # authorization.enabled: true
     default-number-of-retries: 1
     job-execution:
+      enabled: true
+      backoff-decrease-threshold: 100
+      backoff-time-in-millis: 0
+      core-pool-size: 3
+      deployment-aware: false
+      keep-alive-seconds: 0
       lock-time-in-millis: 3600000
+      max-backoff: 0
+      max-jobs-per-acquisition: 3
+      max-pool-size: 10
+      max-wait: 60000
+      queue-capacity: 3
+      wait-increase-factor: 2
+      wait-time-in-millis: 15000
+    # see: https://docs.camunda.org/manual/7.20/user-guide/spring-boot-integration/configuration/#generic-properties 
+    generic-properties:
+      properties:
+        telemetry-reporter-activate: false
+        enable-script-compilation: true
+        enable-script-engine-nashorn-compatibility: true
+        enable-fetch-script-engine-from-process-application: false
 
 springdoc:
   api-docs:


### PR DESCRIPTION
The bpm xml file appears to not be used anymore.
Remove the bpm xml file.

Add all of the bpm configuration settings to the yaml file with the defaults specified so that it is easier to figure them out.

The use of lombok for logging results in a static class name usage for the log. This doesn't work well for an abstract class.
Instead, instantiate the log in a non-static way so that the implementation class name is used.

Remove the unused `camunda.spring.boot.version` from the `pom.xml` file. Add a common version number setting for the graalvm.

Update the graalvm versions.