### PR TITLE
The resource filtering syntax has changed, update the descriptors.

### DIFF
--- a/descriptors/DeploymentDescriptor-template.json
+++ b/descriptors/DeploymentDescriptor-template.json
@@ -1,7 +1,7 @@
 {
-  "srvcId": "${project.artifactId}-${project.version}",
+  "srvcId": "@project.artifactId@-@project.version@",
   "nodeId": "localhost",
   "descriptor": {
-    "exec": "java -Dport=%p -jar ../${artifactId}/target/${project.artifactId}-${project.version}.jar -Dspring.config.location=classpath:/ -Dhttp.port=%p --server.port=%p"
+    "exec": "java -Dport=%p -jar ../@artifactId@/target/@project.artifactId@-@project.version@.jar -Dspring.config.location=classpath:/ -Dhttp.port=%p --server.port=%p"
   }
 }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1,5 +1,5 @@
 {
-  "id": "${project.artifactId}-${project.version}",
+  "id": "@project.artifactId@-@project.version@",
   "name": "Camnuda BPM Module",
   "provides": [
     {
@@ -405,7 +405,7 @@
     }
   ],
   "launchDescriptor": {
-    "dockerImage": "${project.artifactId}:${project.version}",
+    "dockerImage": "@project.artifactId@:@project.version@",
     "dockerPull" : false,
     "dockerArgs": {
       "HostConfig": {

--- a/pom.xml
+++ b/pom.xml
@@ -336,7 +336,6 @@
         <directory>src/main/resources</directory>
         <excludes>
           <exclude>application.yaml</exclude>
-          <exclude>descriptors/**</exclude>
         </excludes>
       </resource>
       <resource>
@@ -348,17 +347,8 @@
       </resource>
       <resource>
         <filtering>true</filtering>
-        <directory>src/main/resources/descriptors</directory>
+        <directory>descriptors</directory>
         <targetPath>descriptors</targetPath>
-        <includes>
-          <include>DeploymentDescriptor.json</include>
-          <include>ModuleDescriptor.json</include>
-        </includes>
-      </resource>
-      <resource>
-        <filtering>true</filtering>
-        <directory>src/main/resources/descriptors</directory>
-        <targetPath>../descriptors</targetPath>
         <includes>
           <include>DeploymentDescriptor.json</include>
           <include>ModuleDescriptor.json</include>

--- a/pom.xml
+++ b/pom.xml
@@ -478,7 +478,7 @@
             </configuration>
             <executions>
               <execution>
-                <id>repackage</id>
+                <id>openapi-repackage</id>
                 <goals>
                   <goal>repackage</goal>
                 </goals>
@@ -487,13 +487,13 @@
                 </configuration>
               </execution>
               <execution>
-                <id>pre-integration-test</id>
+                <id>openapi-repackage-start</id>
                 <goals>
                   <goal>start</goal>
                 </goals>
               </execution>
               <execution>
-                <id>post-integration-test</id>
+                <id>openapi-repackage-stop</id>
                 <goals>
                   <goal>stop</goal>
                 </goals>
@@ -511,7 +511,7 @@
             </configuration>
             <executions>
               <execution>
-              <id>integration-test</id>
+              <id>openapi-generate-api</id>
               <goals>
                 <goal>generate</goal>
               </goals>

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -24,8 +24,8 @@ paths:
               $ref: '#/components/schemas/Workflow'
         required: true
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -42,12 +42,6 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
         "404":
           description: Not Found
           content:
@@ -57,7 +51,7 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
   /workflow-engine/workflows/deactivate/:
@@ -72,8 +66,8 @@ paths:
               $ref: '#/components/schemas/Workflow'
         required: true
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -90,12 +84,6 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
         "404":
           description: Not Found
           content:
@@ -105,7 +93,7 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
   /workflow-engine/workflows/activate/:
@@ -125,8 +113,8 @@ paths:
                   type: string
         required: true
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -143,12 +131,6 @@ paths:
             application/hal+json:
               schema:
                 $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
         "404":
           description: Not Found
           content:
@@ -158,7 +140,7 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
   /workflow-engine/workflows/activate:
@@ -178,8 +160,8 @@ paths:
                   type: string
         required: true
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -192,12 +174,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -211,7 +187,7 @@ paths:
         "200":
           description: OK
           content:
-            application/hal+json:
+            application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
   /_/tenant:
@@ -219,6 +195,12 @@ paths:
       tags:
       - tenant-controller
       operationId: create
+      parameters:
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
@@ -231,8 +213,8 @@ paths:
                   $ref: '#/components/schemas/TenantAttributes'
         required: true
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -245,12 +227,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -271,14 +247,20 @@ paths:
       tags:
       - tenant-controller
       operationId: delete
+      parameters:
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       requestBody:
         content:
           application/json:
             schema:
               type: string
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -291,12 +273,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -313,10 +289,11 @@ paths:
     get:
       tags:
       - Actuator
+      summary: Actuator root web endpoint
       operationId: links
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -329,12 +306,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -373,10 +344,11 @@ paths:
     get:
       tags:
       - Actuator
-      operationId: handle
+      summary: Actuator web endpoint 'info'
+      operationId: info
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -389,12 +361,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -421,10 +387,11 @@ paths:
     get:
       tags:
       - Actuator
-      operationId: handle_1
+      summary: Actuator web endpoint 'health'
+      operationId: health
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -437,12 +404,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -469,10 +430,11 @@ paths:
     get:
       tags:
       - Actuator
-      operationId: handle_2
+      summary: Actuator web endpoint 'health-path'
+      operationId: health-path
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -485,12 +447,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -517,10 +473,11 @@ paths:
     get:
       tags:
       - Actuator
-      operationId: handle_3
+      summary: Actuator web endpoint 'flyway'
+      operationId: flyway
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -533,12 +490,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -577,9 +528,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -592,12 +548,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -630,9 +580,14 @@ paths:
         required: true
         schema:
           type: string
+      - name: accept
+        in: header
+        required: false
+        schema:
+          type: string
       responses:
-        "406":
-          description: Not Acceptable
+        "400":
+          description: Bad Request
           content:
             application/hal+json:
               schema:
@@ -645,12 +600,6 @@ paths:
                 $ref: '#/components/schemas/ResponseErrors'
         "204":
           description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "400":
-          description: Bad Request
           content:
             application/hal+json:
               schema:

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -5,12 +5,13 @@ logging:
   level:
     com:
       zaxxer:
-        hikari: INFO
+        hikari: ERROR
     org:
-      camunda: INFO
-      folio: INFO
-      hibernate: INFO
-      springframework: INFO
+      camunda: WARN
+      folio: WARN
+      hibernate: WARN
+      springframework: WARN
+      springframework.test: INFO
 
       # Uncomment to enable MockMvc unit test logging.
       #springframework.test.web.servlet.result: DEBUG


### PR DESCRIPTION
Deployment is not working as expected.

This also removes some unused configuration, such as the resource exclusion for descriptors under `src/main/resources` (the descriptors are no longer stored there).

This also makes tests easier to discern by reducing excess logging by default while keeping important logging and by providing more descriptive IDs for the openapi modes.
The more descriptive IDs should make reading the logs to determine what is going on when investigating openapi build problems.