### PR TITLE
MODCAMUNDA-7: Add several delegate unit tests and fix relating problems.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/aspect/DelegateExecutionExceptionAspect.java
+++ b/src/main/java/org/folio/rest/camunda/aspect/DelegateExecutionExceptionAspect.java
@@ -19,7 +19,6 @@ public class DelegateExecutionExceptionAspect {
 
   private static final Logger logger = LoggerFactory.getLogger(DelegateExecutionExceptionAspect.class);
 
-  @Autowired
   private JavaMailSender emailSender;
 
   @Value("${error.handling.environment:DEV}")
@@ -30,6 +29,11 @@ public class DelegateExecutionExceptionAspect {
 
   @Value("${error.handling.emailTo}")
   private String errorHandlingEmailTo;
+
+  @Autowired
+  public DelegateExecutionExceptionAspect(JavaMailSender emailSender) {
+      this.emailSender = emailSender;
+  }
 
   @AfterThrowing(pointcut = "execution(* org.camunda.bpm.engine.delegate.JavaDelegate.execute (org.camunda.bpm.engine.delegate.DelegateExecution)) && args(execution))", throwing = "exception")
   public void afterDelegateExecutionThrowsException(DelegateExecution execution, Throwable exception) {

--- a/src/main/java/org/folio/rest/camunda/aspect/TenantInjectionDelegateAspect.java
+++ b/src/main/java/org/folio/rest/camunda/aspect/TenantInjectionDelegateAspect.java
@@ -14,8 +14,12 @@ import org.springframework.stereotype.Component;
 @Component
 public class TenantInjectionDelegateAspect {
 
-  @Autowired
   private TenantProperties tenantProperties;
+
+  @Autowired
+  public TenantInjectionDelegateAspect(TenantProperties tenantProperties) {
+      this.tenantProperties = tenantProperties;
+  }
 
   @Before("execution(* org.camunda.bpm.engine.delegate.JavaDelegate.execute (org.camunda.bpm.engine.delegate.DelegateExecution)) && args(execution)")
   public void beforeDelegateExecution(DelegateExecution execution) {

--- a/src/main/java/org/folio/rest/camunda/config/CamundaTenantInit.java
+++ b/src/main/java/org/folio/rest/camunda/config/CamundaTenantInit.java
@@ -4,7 +4,6 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.UUID;
-
 import org.folio.spring.tenant.hibernate.HibernateTenantInit;
 import org.folio.spring.tenant.service.SqlTemplateService;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,21 +12,26 @@ import org.springframework.stereotype.Component;
 @Component
 public class CamundaTenantInit implements HibernateTenantInit {
 
-  private final static String SCHEMA_IMPORT_TENANT = "import/tenant";
+  private static final String SCHEMA_IMPORT_TENANT = "import/tenant";
 
-  private final static String TENANT_TEMPLATE_KEY = "tenant";
+  private static final String TENANT_TEMPLATE_KEY = "tenant";
+
+  private SqlTemplateService sqlTemplateService;
 
   @Autowired
-  private SqlTemplateService sqlTemplateService;
+  public CamundaTenantInit(SqlTemplateService sqlTemplateService) {
+      this.sqlTemplateService = sqlTemplateService;
+  }
 
   @Override
   public void initialize(Connection connection, String tenant) throws SQLException {
     UUID uuid = UUID.randomUUID();
     String id = uuid.toString();
     CamundaTenant camundaTenant = new CamundaTenant(id, 1, tenant);
-    Statement statement = connection.createStatement();
-    statement.execute(sqlTemplateService.templateInitSql(SCHEMA_IMPORT_TENANT, TENANT_TEMPLATE_KEY, camundaTenant));
-    statement.close();
+
+    try (Statement statement = connection.createStatement()) {
+      statement.execute(sqlTemplateService.templateInitSql(SCHEMA_IMPORT_TENANT, TENANT_TEMPLATE_KEY, camundaTenant));
+    }
   }
 
   public class CamundaTenant {

--- a/src/main/java/org/folio/rest/camunda/config/WebClientConfig.java
+++ b/src/main/java/org/folio/rest/camunda/config/WebClientConfig.java
@@ -41,9 +41,7 @@ public class WebClientConfig {
 
   @Bean
   public ReactorClientHttpConnector reactorClientHttpConnector(ReactorResourceFactory factory) {
-    return new ReactorClientHttpConnector(factory, connection -> {
-      return connection;
-    });
+    return new ReactorClientHttpConnector(factory, connection -> connection);
   }
 
   @Bean

--- a/src/main/java/org/folio/rest/camunda/controller/WorkflowController.java
+++ b/src/main/java/org/folio/rest/camunda/controller/WorkflowController.java
@@ -18,8 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping({"/workflow-engine/workflows", "/workflow-engine/workflows/"})
 public class WorkflowController {
 
-  @Autowired
   private CamundaApiService camundaApiService;
+
+  @Autowired
+  public WorkflowController(CamundaApiService camundaApiService) {
+    this.camundaApiService = camundaApiService;
+  }
 
   @PostMapping(value = {"/activate", "/activate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow activateWorkflow(@RequestBody Workflow workflow, @TenantHeader String tenant)

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractDatabaseOutputDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractDatabaseOutputDelegate.java
@@ -10,8 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
-// This class probably should be called AbstractDatabaseIODelegate to align with AbstractWorkflowIODelegate.
-// Deferring refactor at this time in case it may cause breaking changes.
+/**
+ * This class probably should be called AbstractDatabaseIODelegate to align with AbstractWorkflowIODelegate.
+ *
+ * Deferring refactor at this time in case it may cause breaking changes.
+ */
 public abstract class AbstractDatabaseOutputDelegate extends AbstractWorkflowInputDelegate implements Output {
 
   Expression designation;
@@ -25,9 +28,8 @@ public abstract class AbstractDatabaseOutputDelegate extends AbstractWorkflowInp
     this.designation = designation;
   }
 
-  public Boolean hasOutputVariable(DelegateExecution execution) {
-    return Objects.nonNull(outputVariable) &&
-        Objects.nonNull(outputVariable.getValue(execution));
+  public boolean hasOutputVariable(DelegateExecution execution) {
+    return Objects.nonNull(outputVariable) && Objects.nonNull(outputVariable.getValue(execution));
   }
 
   public EmbeddedVariable getOutputVariable(DelegateExecution execution) throws JsonProcessingException {

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegate.java
@@ -5,17 +5,22 @@ import org.camunda.bpm.engine.delegate.Expression;
 import org.folio.rest.workflow.model.EmbeddedVariable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Objects;
 
 public abstract class AbstractWorkflowIODelegate extends AbstractWorkflowInputDelegate implements Output {
 
   private Expression outputVariable;
 
-  public AbstractWorkflowIODelegate() {
+  protected AbstractWorkflowIODelegate() {
     super();
   }
 
   public EmbeddedVariable getOutputVariable(DelegateExecution execution) throws JsonProcessingException {
     return objectMapper.readValue(outputVariable.getValue(execution).toString(), EmbeddedVariable.class);
+  }
+
+  public boolean hasOutputVariable(DelegateExecution execution) {
+    return Objects.nonNull(outputVariable) && Objects.nonNull(outputVariable.getValue(execution));
   }
 
   public void setOutputVariable(Expression outputVariable) {

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegate.java
@@ -1,5 +1,6 @@
 package org.folio.rest.camunda.delegate;
 
+import java.util.Objects;
 import java.util.Set;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
@@ -13,15 +14,17 @@ public abstract class AbstractWorkflowInputDelegate extends AbstractWorkflowDele
 
   private Expression inputVariables;
 
-  public AbstractWorkflowInputDelegate() {
+  protected AbstractWorkflowInputDelegate() {
     super();
   }
 
   public Set<EmbeddedVariable> getInputVariables(DelegateExecution execution) throws JsonProcessingException {
-    // @formatter:off
     return objectMapper.readValue(inputVariables.getValue(execution).toString(),
         new TypeReference<Set<EmbeddedVariable>>() {});
-    // @formatter:on
+  }
+
+  public boolean hasInputVariables(DelegateExecution execution) {
+    return Objects.nonNull(inputVariables) && Objects.nonNull(inputVariables.getValue(execution));
   }
 
   public void setInputVariables(Expression inputVariables) {

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegate.java
@@ -5,17 +5,22 @@ import org.camunda.bpm.engine.delegate.Expression;
 import org.folio.rest.workflow.model.EmbeddedVariable;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Objects;
 
 public abstract class AbstractWorkflowOutputDelegate extends AbstractWorkflowDelegate implements Output {
 
   private Expression outputVariable;
 
-  public AbstractWorkflowOutputDelegate() {
+  protected AbstractWorkflowOutputDelegate() {
     super();
   }
 
   public EmbeddedVariable getOutputVariable(DelegateExecution execution) throws JsonProcessingException {
     return objectMapper.readValue(outputVariable.getValue(execution).toString(), EmbeddedVariable.class);
+  }
+
+  public boolean hasOutputVariable(DelegateExecution execution) {
+    return Objects.nonNull(outputVariable) && Objects.nonNull(outputVariable.getValue(execution));
   }
 
   public void setOutputVariable(Expression outputVariable) {

--- a/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
@@ -106,27 +106,11 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
         break;
     }
 
-    switch (useContainer) {
-      case TAR:
-        extension = EXT_TAR + extension;
-        break;
-
-      default:
-        break;
+    if (useContainer == CompressFileContainer.TAR) {
+      extension = EXT_TAR + extension;
     }
 
-    if (sourceFile.exists()) {
-      if (!sourceFile.canRead()) {
-        getLogger().info("{} could not be read", sourcePath);
-        formatType = null;
-      }
-
-      if (useContainer == CompressFileContainer.NONE && sourceFile.isDirectory()) {
-        getLogger().info("{} is a directory and cannot be compressed when container is NONE", sourcePath);
-        formatType = null;
-      }
-    } else {
-      getLogger().info("{} does not exist", sourcePath);
+    if (soureFileHasProblems(sourceFile, sourcePath,  useContainer)) {
       formatType = null;
     }
 
@@ -237,6 +221,36 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
     entry.setModTime(Files.getLastModifiedTime(filePath).toMillis());
 
     tar.putArchiveEntry(entry);
+  }
+
+  /**
+   * Helper function for execute() to help solve "S3776" coding practice.
+   *
+   * @param sourceFile The source file.
+   * @param sourcePath The source path.
+   * @param useContainer The container.
+   *
+   * @return True if the source file has problems and false otherwise.
+   */
+  private boolean soureFileHasProblems(File sourceFile, String sourcePath, CompressFileContainer useContainer) {
+    boolean hasProblems = false;
+
+    if (sourceFile.exists()) {
+      if (!sourceFile.canRead()) {
+        getLogger().info("{} could not be read", sourcePath);
+        hasProblems = true;
+      }
+
+      if (useContainer == CompressFileContainer.NONE && sourceFile.isDirectory()) {
+        getLogger().info("{} is a directory and cannot be compressed when container is NONE", sourcePath);
+        hasProblems = true;
+      }
+    } else {
+      getLogger().info("{} does not exist", sourcePath);
+      hasProblems = true;
+    }
+
+    return hasProblems;
   }
 
 }

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
@@ -25,14 +25,14 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
 
     getLogger().info("{} started", delegateName);
 
-    String url = this.url.getValue(execution).toString();
+    String urlValue = this.url.getValue(execution).toString();
     String key = this.designation.getValue(execution).toString();
 
     Properties info = new Properties();
     info.setProperty("user", this.username.getValue(execution).toString());
     info.setProperty("password", this.password.getValue(execution).toString());
 
-    connectionService.createPool(key, url, info);
+    connectionService.createPool(key, urlValue, info);
 
     long endTime = System.nanoTime();
     getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);

--- a/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
@@ -54,7 +54,7 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
     Map<String, Object> inputs = getInputs(execution);
 
     String filePath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("path"), inputs);
-    Integer line = Integer.parseInt(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("line"), inputs));
+    Integer lineValue = Integer.parseInt(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("line"), inputs));
 
     FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
 
@@ -75,7 +75,6 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
         if (file.exists()) {
           try (BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8)) {
             long lineCount = reader.lines().count();
-            reader.close();
             setOutput(execution, lineCount);
             getLogger().info("{} read", filePath);
           }
@@ -84,11 +83,11 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
         }
         break;
       case READ_LINE:
-        if (file.exists() && line > 0) {
+        if (file.exists() && lineValue > 0) {
           try (BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8)) {
             int lineCount = 0;
             String currerntLine = "";
-            while ((currerntLine = reader.readLine()) != null && (++lineCount) < line) {}
+            while ((currerntLine = reader.readLine()) != null && (++lineCount) < lineValue) {}
             reader.close();
             setOutput(execution, currerntLine);
             getLogger().info("{} read", filePath);

--- a/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
@@ -44,23 +44,23 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
 
     getLogger().info("{} started", delegateName);
 
-    String originPath = this.originPath.getValue(execution).toString();
+    String originPathValue = this.originPath.getValue(execution).toString();
 
-    String destinationPath = this.destinationPath.getValue(execution).toString();
+    String destinationPathValue = this.destinationPath.getValue(execution).toString();
 
-    SftpOp op = SftpOp.valueOf(this.op.getValue(execution).toString());
+    SftpOp opValue = SftpOp.valueOf(this.op.getValue(execution).toString());
 
-    String scheme = this.scheme.getValue(execution).toString();
+    String schemeValue = this.scheme.getValue(execution).toString();
 
-    String host = this.host.getValue(execution).toString();
+    String hostValue = this.host.getValue(execution).toString();
 
-    int port = Integer.parseInt(this.port.getValue(execution).toString());
+    int portValue = Integer.parseInt(this.port.getValue(execution).toString());
 
-    Optional<String> username = Objects.nonNull(this.username)
+    Optional<String> usernameValue = Objects.nonNull(this.username)
       ? Optional.ofNullable(this.username.getValue(execution).toString())
       : Optional.empty();
 
-    Optional<String> password = Objects.nonNull(this.password)
+    Optional<String> passwordValue = Objects.nonNull(this.password)
       ? Optional.ofNullable(this.password.getValue(execution).toString())
       : Optional.empty();
 
@@ -68,25 +68,25 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
 
     String userInfo = null;
 
-    if (username.isPresent()) {
-      userInfo = username.get();
+    if (usernameValue.isPresent()) {
+      userInfo = usernameValue.get();
     }
 
-    if (password.isPresent()) {
-      userInfo += ":" + password.get();
+    if (passwordValue.isPresent()) {
+      userInfo += ":" + passwordValue.get();
     }
 
-    switch (op) {
+    switch (opValue) {
       case GET: {
 
-        File file = new File(destinationPath);
+        File file = new File(destinationPathValue);
 
         URI uri = new URI(
-          scheme,
+          schemeValue,
           userInfo,
-          host,
-          port,
-          originPath,
+          hostValue,
+          portValue,
+          originPathValue,
           null,
           null
         );
@@ -101,14 +101,14 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
       } break;
       case PUT: {
 
-        File file = new File(originPath);
+        File file = new File(originPathValue);
 
         URI uri = new URI(
-          scheme,
+          schemeValue,
           userInfo,
-          host,
-          port,
-          destinationPath,
+          hostValue,
+          portValue,
+          destinationPathValue,
           null,
           null
         );

--- a/src/main/java/org/folio/rest/camunda/delegate/Output.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/Output.java
@@ -4,8 +4,6 @@ import static org.camunda.spin.Spin.JSON;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Objects;
-import java.util.Optional;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.camunda.bpm.engine.variable.Variables;
@@ -23,34 +21,38 @@ public interface Output {
 
   public abstract void setOutputVariable(Expression outputVariable);
 
+  public abstract boolean hasOutputVariable(DelegateExecution execution);
+
   public default void setOutput(DelegateExecution execution, Object output) throws JsonProcessingException {
+    if (!hasOutputVariable(execution)) {
+      getLogger().warn("Output variable for execution {} is null", execution.getId());
+      return;
+    }
+
     EmbeddedVariable variable = getOutputVariable(execution);
-    Optional<String> key = Optional.ofNullable(variable.getKey());
-    if (key.isPresent()) {
-      if (Objects.nonNull(output)) {
-        Optional<VariableType> type = Optional.ofNullable(variable.getType());
-        Object value = variable.isSpin()
-          ? JSON(getObjectMapper().writeValueAsString(output))
-          : Variables.objectValue(output, variable.getAsTransient()).create();
-        if (type.isPresent()) {
-          switch (type.get()) {
-          case LOCAL:
-            execution.setVariableLocal(key.get(), value);
-            break;
-          case PROCESS:
-            execution.setVariable(key.get(), value);
-            break;
-          default:
-            break;
-          }
-        } else {
-          getLogger().warn("Variable type not present for {}", key.get());
-        }
-      } else {
-        getLogger().warn("Output not present for {}", key.get());
-      }
-    } else {
+    String key = variable.getKey();
+
+    if (key == null) {
       getLogger().warn("Output key is null");
+      return;
+    }
+
+    if (output == null) {
+       getLogger().warn("Output not present for {}", key);
+      return;
+    }
+
+    VariableType type = variable.getType();
+    Object value = variable.isSpin()
+      ? JSON(getObjectMapper().writeValueAsString(output))
+      : Variables.objectValue(output, variable.getAsTransient()).create();
+
+    if (type == VariableType.LOCAL) {
+      execution.setVariableLocal(key, value);
+    } else if (type == VariableType.PROCESS) {
+      execution.setVariable(key, value);
+    } else {
+      getLogger().warn("Variable type not present for {}", key);
     }
   }
 

--- a/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
@@ -31,11 +31,11 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
 
     getLogger().info("{} started", delegateName);
 
-    EmbeddedProcessor processor = objectMapper.readValue(this.processor.getValue(execution).toString(), EmbeddedProcessor.class);
+    EmbeddedProcessor processorValue = objectMapper.readValue(this.processor.getValue(execution).toString(), EmbeddedProcessor.class);
 
-    String scriptName = processor.getFunctionName();
+    String scriptName = processorValue.getFunctionName();
 
-    String scriptTypeExtension = processor.getScriptType().getExtension();
+    String scriptTypeExtension = processorValue.getScriptType().getExtension();
 
     Map<String, Object> inputs = getInputs(execution);
 

--- a/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
@@ -21,8 +21,8 @@ import com.fasterxml.jackson.core.type.TypeReference;
 @Scope("prototype")
 public class SetupDelegate extends AbstractRuntimeDelegate {
 
-  private final static String TIMESTAMP_VARIABLE_NAME = "timestamp";
-  private final static String TENANT_VARIABLE_NAME = "tenantId";
+  private static final String TIMESTAMP_VARIABLE_NAME = "timestamp";
+  private static final String TENANT_VARIABLE_NAME = "tenantId";
 
   @Autowired
   private ScriptEngineService scriptEngineService;
@@ -58,11 +58,11 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
 
     getLogger().info("loading scripts");
 
-    List<EmbeddedProcessor> processors = objectMapper.readValue(this.processors.getValue(execution).toString(),
+    List<EmbeddedProcessor> processorsValue = objectMapper.readValue(this.processors.getValue(execution).toString(),
         new TypeReference<List<EmbeddedProcessor>>() {
         });
 
-    for (EmbeddedProcessor processor : processors) {
+    for (EmbeddedProcessor processor : processorsValue) {
       String extension = processor.getScriptType().getExtension();
       String functionName = processor.getFunctionName();
       String code = processor.getCode();

--- a/src/main/java/org/folio/rest/camunda/exception/WorkflowAlreadyActiveException.java
+++ b/src/main/java/org/folio/rest/camunda/exception/WorkflowAlreadyActiveException.java
@@ -4,7 +4,7 @@ public class WorkflowAlreadyActiveException extends Exception {
 
   private static final long serialVersionUID = -7896387728725860219L;
 
-  private final static String WORKFLOW_ALREADY_ACTIVE_MESSAGE = "The workflow: %s, is already active.";
+  private static final String WORKFLOW_ALREADY_ACTIVE_MESSAGE = "The workflow: %s, is already active.";
 
   public WorkflowAlreadyActiveException(String id) {
     super(String.format(WORKFLOW_ALREADY_ACTIVE_MESSAGE, id));

--- a/src/main/java/org/folio/rest/camunda/exception/WorkflowAlreadyDeactivatedException.java
+++ b/src/main/java/org/folio/rest/camunda/exception/WorkflowAlreadyDeactivatedException.java
@@ -4,7 +4,7 @@ public class WorkflowAlreadyDeactivatedException extends Exception {
 
   private static final long serialVersionUID = -3039895403839535313L;
 
-  private final static String WORKFLOW_ALREADY_DEACTIVATED_MESSAGE = "The workflow: %s, is already deactivated.";
+  private static final String WORKFLOW_ALREADY_DEACTIVATED_MESSAGE = "The workflow: %s, is already deactivated.";
 
   public WorkflowAlreadyDeactivatedException(String id) {
     super(String.format(WORKFLOW_ALREADY_DEACTIVATED_MESSAGE, id));

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseDelegateTest.java
@@ -8,17 +8,17 @@ import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractDatabaseDelegateTest {
 
   @Mock
-  Expression designation;
+  private Expression designation;
 
-  @InjectMocks
+  @Spy
   private Impl abstractDatabaseDelegate;
 
   @Test
@@ -38,6 +38,7 @@ class AbstractDatabaseDelegateTest {
     @Override
     public Class<?> fromTask() {
       return null;
-    } };
+    }
+  };
 
 }

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseOutputDelegateTest.java
@@ -1,0 +1,111 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.folio.rest.workflow.enums.VariableType;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractDatabaseOutputDelegateTest {
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression outputVariable;
+
+  @InjectMocks
+  private ObjectMapper objectMapper;
+
+  @Spy
+  private Impl abstractDatabaseOutputDelegate;
+
+  @Test
+  void testSetDesignationWorks() {
+    setField(abstractDatabaseOutputDelegate, "designation", null);
+
+    abstractDatabaseOutputDelegate.setDesignation(outputVariable);
+    assertEquals(outputVariable, getField(abstractDatabaseOutputDelegate, "designation"));
+  }
+
+  @Test
+  void testHasOutputVariableReturnsTrue() {
+    when(outputVariable.getValue(any())).thenReturn(JSON_OBJECT);
+    setField(abstractDatabaseOutputDelegate, "outputVariable", outputVariable);
+
+    assertTrue(abstractDatabaseOutputDelegate.hasOutputVariable(delegateExecution));
+  }
+
+  @Test
+  void testHasOutputVariableReturnsFalse() {
+    when(outputVariable.getValue(any())).thenReturn(null);
+    setField(abstractDatabaseOutputDelegate, "outputVariable", outputVariable);
+
+    assertFalse(abstractDatabaseOutputDelegate.hasOutputVariable(delegateExecution));
+
+    setField(abstractDatabaseOutputDelegate, "outputVariable", null);
+
+    assertFalse(abstractDatabaseOutputDelegate.hasOutputVariable(delegateExecution));
+  }
+
+  @Test
+  void testGetOutputVariableWorks() throws JsonProcessingException {
+    final EmbeddedVariable embeddedVariable = new EmbeddedVariable();
+    embeddedVariable.setKey(KEY);
+    embeddedVariable.setAsJson(true);
+    embeddedVariable.setAsTransient(true);
+    embeddedVariable.setSpin(true);
+    embeddedVariable.setType(VariableType.LOCAL);
+
+    when(outputVariable.getValue(any())).thenReturn(objectMapper.writeValueAsString(embeddedVariable));
+    setField(abstractDatabaseOutputDelegate, "outputVariable", outputVariable);
+    setField(abstractDatabaseOutputDelegate, "objectMapper", objectMapper);
+
+    final EmbeddedVariable responseVariable = abstractDatabaseOutputDelegate.getOutputVariable(delegateExecution);
+
+    assertEquals(embeddedVariable.getKey(), responseVariable.getKey());
+    assertEquals(embeddedVariable.getAsJson(), responseVariable.getAsJson());
+    assertEquals(embeddedVariable.getAsTransient(), responseVariable.getAsTransient());
+    assertEquals(embeddedVariable.isSpin(), responseVariable.isSpin());
+    assertEquals(embeddedVariable.getType(), responseVariable.getType());
+  }
+
+  @Test
+  void testSetOutputVariableWorks() {
+    setField(abstractDatabaseOutputDelegate, "outputVariable", null);
+
+    abstractDatabaseOutputDelegate.setOutputVariable(outputVariable);
+    assertEquals(outputVariable, getField(abstractDatabaseOutputDelegate, "outputVariable"));
+  }
+
+  private static class Impl extends AbstractDatabaseOutputDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+    }
+
+    @Override
+    public Class<?> fromTask() {
+      return null;
+    }
+  };
+
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
@@ -1,0 +1,54 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractDelegateTest {
+
+  @Mock
+  private ObjectMapper objectMapper;
+
+  @Spy
+  private Impl abstractDelegate;
+
+  @Test
+  void getExpressionWorksTest() {
+    final String simpleName = Impl.class.getSimpleName();
+    final String delegateName = "${" + simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1) + "}";
+
+    assertEquals(delegateName, abstractDelegate.getExpression());
+  }
+
+  @Test
+  void getLoggerWorksTest() {
+    final Logger expectLog = LoggerFactory.getLogger(Impl.class);
+
+    assertEquals(expectLog.getName(), abstractDelegate.getLogger().getName());
+  }
+
+  @Test
+  void getObjectMapperWorksTest() {
+    setField(abstractDelegate, "objectMapper", objectMapper);
+
+    assertEquals(objectMapper, abstractDelegate.getObjectMapper());
+  }
+
+  private static class Impl extends AbstractDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+    }
+  };
+
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
@@ -1,0 +1,114 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.folio.rest.workflow.enums.VariableType;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractWorkflowIODelegateTest {
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression inputVariables;
+
+  @Mock
+  private Expression outputVariable;
+
+  @InjectMocks
+  private ObjectMapper objectMapper;
+
+  @Spy
+  private Impl abstractWorkflowIODelegate;
+
+  @Test
+  void testGetOutputVariableWorks() throws JsonProcessingException {
+    final EmbeddedVariable embeddedVariable = new EmbeddedVariable();
+    embeddedVariable.setKey(KEY);
+    embeddedVariable.setAsJson(true);
+    embeddedVariable.setAsTransient(true);
+    embeddedVariable.setSpin(true);
+    embeddedVariable.setType(VariableType.LOCAL);
+
+    when(outputVariable.getValue(any())).thenReturn(objectMapper.writeValueAsString(embeddedVariable));
+    setField(abstractWorkflowIODelegate, "outputVariable", outputVariable);
+    setField(abstractWorkflowIODelegate, "objectMapper", objectMapper);
+
+    final EmbeddedVariable responseVariable = abstractWorkflowIODelegate.getOutputVariable(delegateExecution);
+
+    assertEquals(embeddedVariable.getKey(), responseVariable.getKey());
+    assertEquals(embeddedVariable.getAsJson(), responseVariable.getAsJson());
+    assertEquals(embeddedVariable.getAsTransient(), responseVariable.getAsTransient());
+    assertEquals(embeddedVariable.isSpin(), responseVariable.isSpin());
+    assertEquals(embeddedVariable.getType(), responseVariable.getType());
+  }
+
+  @Test
+  void testHasOutputVariablesReturnsTrue() {
+    when(inputVariables.getValue(any())).thenReturn(JSON_OBJECT);
+    setField(abstractWorkflowIODelegate, "inputVariables", inputVariables);
+
+    assertTrue(abstractWorkflowIODelegate.hasInputVariables(delegateExecution));
+  }
+
+  @Test
+  void testHasOutputVariableReturnsTrue() {
+    when(outputVariable.getValue(any())).thenReturn(JSON_OBJECT);
+    setField(abstractWorkflowIODelegate, "outputVariable", outputVariable);
+
+    assertTrue(abstractWorkflowIODelegate.hasOutputVariable(delegateExecution));
+  }
+
+  @Test
+  void testHasOutputVariableReturnsFalse() {
+    when(outputVariable.getValue(any())).thenReturn(null);
+    setField(abstractWorkflowIODelegate, "outputVariable", outputVariable);
+
+    assertFalse(abstractWorkflowIODelegate.hasOutputVariable(delegateExecution));
+
+    setField(abstractWorkflowIODelegate, "outputVariable", null);
+
+    assertFalse(abstractWorkflowIODelegate.hasOutputVariable(delegateExecution));
+  }
+
+  @Test
+  void testSetOutputVariableWorks() {
+    setField(abstractWorkflowIODelegate, "outputVariable", null);
+
+    abstractWorkflowIODelegate.setOutputVariable(outputVariable);
+    assertEquals(outputVariable, getField(abstractWorkflowIODelegate, "outputVariable"));
+  }
+
+  private static class Impl extends AbstractWorkflowIODelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+    }
+
+    @Override
+    public Class<?> fromTask() {
+      return null;
+    }
+  };
+
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
@@ -1,0 +1,112 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.folio.rest.workflow.enums.VariableType;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractWorkflowInputDelegateTest {
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression inputVariables;
+
+  @InjectMocks
+  private ObjectMapper objectMapper;
+
+  @Spy
+  private Impl abstractDatabaseInputDelegate;
+
+  @Test
+  void testGetInputVariableWorks() throws JsonProcessingException {
+    final EmbeddedVariable embeddedVariable = new EmbeddedVariable();
+    embeddedVariable.setKey(KEY);
+    embeddedVariable.setAsJson(true);
+    embeddedVariable.setAsTransient(true);
+    embeddedVariable.setSpin(true);
+    embeddedVariable.setType(VariableType.LOCAL);
+    Set<EmbeddedVariable> variables = new HashSet<>(List.of(embeddedVariable));
+
+    when(inputVariables.getValue(any())).thenReturn(objectMapper.writeValueAsString(variables));
+    setField(abstractDatabaseInputDelegate, "inputVariables", inputVariables);
+    setField(abstractDatabaseInputDelegate, "objectMapper", objectMapper);
+
+    final Set<EmbeddedVariable> responseVariables = abstractDatabaseInputDelegate.getInputVariables(delegateExecution);
+
+    assertEquals(variables.size(), responseVariables.size());
+
+    variables.forEach(ev -> {
+      assertEquals(embeddedVariable.getKey(), ev.getKey());
+      assertEquals(embeddedVariable.getKey(), ev.getKey());
+      assertEquals(embeddedVariable.getAsJson(), ev.getAsJson());
+      assertEquals(embeddedVariable.getAsTransient(), ev.getAsTransient());
+      assertEquals(embeddedVariable.isSpin(), ev.isSpin());
+      assertEquals(embeddedVariable.getType(), ev.getType());
+    });
+  }
+
+  @Test
+  void testHasInputVariablesReturnsTrue() {
+    when(inputVariables.getValue(any())).thenReturn(JSON_OBJECT);
+    setField(abstractDatabaseInputDelegate, "inputVariables", inputVariables);
+
+    assertTrue(abstractDatabaseInputDelegate.hasInputVariables(delegateExecution));
+  }
+
+  @Test
+  void testHasInputVariablesReturnsFalse() {
+    when(inputVariables.getValue(any())).thenReturn(null);
+    setField(abstractDatabaseInputDelegate, "inputVariables", inputVariables);
+
+    assertFalse(abstractDatabaseInputDelegate.hasInputVariables(delegateExecution));
+
+    setField(abstractDatabaseInputDelegate, "inputVariables", null);
+
+    assertFalse(abstractDatabaseInputDelegate.hasInputVariables(delegateExecution));
+  }
+
+  @Test
+  void testSetInputVariableWorks() {
+    setField(abstractDatabaseInputDelegate, "inputVariables", null);
+
+    abstractDatabaseInputDelegate.setInputVariables(inputVariables);
+    assertEquals(inputVariables, getField(abstractDatabaseInputDelegate, "inputVariables"));
+  }
+
+  private static class Impl extends AbstractWorkflowInputDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+    }
+
+    @Override
+    public Class<?> fromTask() {
+      return null;
+    }
+  };
+
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
@@ -1,0 +1,103 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.folio.rest.workflow.enums.VariableType;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AbstractWorkflowOutputDelegateTest {
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression outputVariable;
+
+  @InjectMocks
+  private ObjectMapper objectMapper;
+
+  @Spy
+  private Impl abstractWorkflowOutputDelegate;
+
+  @Test
+  void testGetOutputVariableWorks() throws JsonProcessingException {
+    final EmbeddedVariable embeddedVariable = new EmbeddedVariable();
+    embeddedVariable.setKey(KEY);
+    embeddedVariable.setAsJson(true);
+    embeddedVariable.setAsTransient(true);
+    embeddedVariable.setSpin(true);
+    embeddedVariable.setType(VariableType.LOCAL);
+
+    when(outputVariable.getValue(any())).thenReturn(objectMapper.writeValueAsString(embeddedVariable));
+    setField(abstractWorkflowOutputDelegate, "outputVariable", outputVariable);
+    setField(abstractWorkflowOutputDelegate, "objectMapper", objectMapper);
+
+    final EmbeddedVariable responseVariable = abstractWorkflowOutputDelegate.getOutputVariable(delegateExecution);
+
+    assertEquals(embeddedVariable.getKey(), responseVariable.getKey());
+    assertEquals(embeddedVariable.getAsJson(), responseVariable.getAsJson());
+    assertEquals(embeddedVariable.getAsTransient(), responseVariable.getAsTransient());
+    assertEquals(embeddedVariable.isSpin(), responseVariable.isSpin());
+    assertEquals(embeddedVariable.getType(), responseVariable.getType());
+  }
+
+  @Test
+  void testHasOutputVariableReturnsTrue() {
+    when(outputVariable.getValue(any())).thenReturn(JSON_OBJECT);
+    setField(abstractWorkflowOutputDelegate, "outputVariable", outputVariable);
+
+    assertTrue(abstractWorkflowOutputDelegate.hasOutputVariable(delegateExecution));
+  }
+
+  @Test
+  void testHasOutputVariableReturnsFalse() {
+    when(outputVariable.getValue(any())).thenReturn(null);
+    setField(abstractWorkflowOutputDelegate, "outputVariable", outputVariable);
+
+    assertFalse(abstractWorkflowOutputDelegate.hasOutputVariable(delegateExecution));
+
+    setField(abstractWorkflowOutputDelegate, "outputVariable", null);
+
+    assertFalse(abstractWorkflowOutputDelegate.hasOutputVariable(delegateExecution));
+  }
+
+  @Test
+  void testSetOutputVariableWorks() {
+    setField(abstractWorkflowOutputDelegate, "outputVariable", null);
+
+    abstractWorkflowOutputDelegate.setOutputVariable(outputVariable);
+    assertEquals(outputVariable, getField(abstractWorkflowOutputDelegate, "outputVariable"));
+  }
+
+  private static class Impl extends AbstractWorkflowOutputDelegate {
+
+    @Override
+    public void execute(DelegateExecution execution) throws Exception {
+    }
+
+    @Override
+    public Class<?> fromTask() {
+      return null;
+    }
+  };
+
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/CompressFileDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/CompressFileDelegateTest.java
@@ -1,0 +1,65 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.folio.rest.workflow.model.CompressFileTask;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CompressFileDelegateTest {
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression expression;
+
+  @Spy
+  private CompressFileDelegate compressFileDelegate;
+
+  @Test
+  void testSetSourceWorks() {
+    setField(compressFileDelegate, "source", null);
+
+    compressFileDelegate.setSource(expression);
+    assertEquals(expression, getField(compressFileDelegate, "source"));
+  }
+
+  @Test
+  void testSetDestinationWorks() {
+    setField(compressFileDelegate, "destination", null);
+
+    compressFileDelegate.setDestination(expression);
+    assertEquals(expression, getField(compressFileDelegate, "destination"));
+  }
+
+  @Test
+  void testSetFormatWorks() {
+    setField(compressFileDelegate, "format", null);
+
+    compressFileDelegate.setFormat(expression);
+    assertEquals(expression, getField(compressFileDelegate, "format"));
+  }
+
+  @Test
+  void testSetContainerWorks() {
+    setField(compressFileDelegate, "container", null);
+
+    compressFileDelegate.setContainer(expression);
+    assertEquals(expression, getField(compressFileDelegate, "container"));
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(CompressFileTask.class, compressFileDelegate.fromTask());
+  }
+
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegateTest.java
@@ -1,0 +1,132 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.folio.spring.test.mock.MockMvcConstant.URL;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.sql.SQLException;
+import java.util.Properties;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.camunda.bpm.model.bpmn.instance.FlowElement;
+import org.folio.rest.camunda.service.DatabaseConnectionService;
+import org.folio.rest.workflow.model.DatabaseConnectionTask;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseConnectionDelegateTest {
+
+  private static final String USERNAME = "username";
+
+  private static final String PASSWORD = "password";
+
+  @Mock
+  private DatabaseConnectionService connectionService;
+
+  @Mock
+  private FlowElement flowElementBpmn;
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression designationExpression;
+
+  @Mock
+  private Expression genericExpression;
+
+  @Mock
+  private Expression passwordExpression;
+
+  @Mock
+  private Expression urlExpression;
+
+  @Mock
+  private Expression usernameExpression;
+
+  @Spy
+  private DatabaseConnectionDelegate databaseConnectionDelegate;
+
+  @Test
+  void testExecuteWorks() throws Exception {
+    setupExecuteMocking();
+
+    doNothing().when(connectionService).createPool(anyString(), anyString(), any(Properties.class));
+
+    databaseConnectionDelegate.execute(delegateExecution);
+
+    verify(connectionService).createPool(anyString(), anyString(), any(Properties.class));
+  }
+
+  @Test
+  void testExecuteThrowsException() throws SQLException {
+    setupExecuteMocking();
+
+    doThrow(SQLException.class).when(connectionService).createPool(anyString(), anyString(), any(Properties.class));
+
+    assertThrows(Exception.class, () -> {
+      databaseConnectionDelegate.execute(delegateExecution);
+    });
+  }
+
+  @Test
+  void testSetUrlWorks() {
+    setField(databaseConnectionDelegate, "url", null);
+
+    databaseConnectionDelegate.setUrl(genericExpression);
+    assertEquals(genericExpression, getField(databaseConnectionDelegate, "url"));
+  }
+
+  @Test
+  void testSetUsernameWorks() {
+    setField(databaseConnectionDelegate, "username", null);
+
+    databaseConnectionDelegate.setUsername(genericExpression);
+    assertEquals(genericExpression, getField(databaseConnectionDelegate, "username"));
+  }
+
+  @Test
+  void testSetPasswordWorks() {
+    setField(databaseConnectionDelegate, "password", null);
+
+    databaseConnectionDelegate.setPassword(genericExpression);
+    assertEquals(genericExpression, getField(databaseConnectionDelegate, "password"));
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(DatabaseConnectionTask.class, databaseConnectionDelegate.fromTask());
+  }
+
+  /**
+   * Provide common mocking behavior for the execute() method.
+   */
+  private void setupExecuteMocking() {
+    when(delegateExecution.getBpmnModelElementInstance()).thenReturn(flowElementBpmn);
+    when(flowElementBpmn.getName()).thenReturn(KEY);
+    when(urlExpression.getValue(any())).thenReturn(URL);
+    when(designationExpression.getValue(any())).thenReturn(VALUE);
+    when(usernameExpression.getValue(any())).thenReturn(USERNAME);
+    when(passwordExpression.getValue(any())).thenReturn(PASSWORD);
+
+    setField(databaseConnectionDelegate, "url", urlExpression);
+    setField(databaseConnectionDelegate, "designation", designationExpression);
+    setField(databaseConnectionDelegate, "username", usernameExpression);
+    setField(databaseConnectionDelegate, "password", passwordExpression);
+    setField(databaseConnectionDelegate, "connectionService", connectionService);
+  }
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/DatabaseDisconnectDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/DatabaseDisconnectDelegateTest.java
@@ -1,0 +1,83 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import java.sql.SQLException;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.camunda.bpm.model.bpmn.instance.FlowElement;
+import org.folio.rest.camunda.service.DatabaseConnectionService;
+import org.folio.rest.workflow.model.DatabaseDisconnectTask;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseDisconnectDelegateTest {
+
+  @Mock
+  private DatabaseConnectionService connectionService;
+
+  @Mock
+  private FlowElement flowElementBpmn;
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private Expression designationExpression;
+
+  @Spy
+  private DatabaseDisconnectDelegate databaseDisconnectDelegate;
+
+  @Test
+  void testExecuteWorks() throws Exception {
+    setupExecuteMocking();
+
+    doNothing().when(connectionService).destroyConnection(anyString());
+
+    databaseDisconnectDelegate.execute(delegateExecution);
+
+    verify(connectionService).destroyConnection(anyString());
+  }
+
+  @Test
+  void testExecuteThrowsException() throws SQLException {
+    setupExecuteMocking();
+
+    doThrow(SQLException.class).when(connectionService).destroyConnection(anyString());
+
+    assertThrows(Exception.class, () -> {
+      databaseDisconnectDelegate.execute(delegateExecution);
+    });
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(DatabaseDisconnectTask.class, databaseDisconnectDelegate.fromTask());
+  }
+
+  /**
+   * Provide common mocking behavior for the execute() method.
+   */
+  private void setupExecuteMocking() {
+    when(delegateExecution.getBpmnModelElementInstance()).thenReturn(flowElementBpmn);
+    when(flowElementBpmn.getName()).thenReturn(KEY);
+    when(designationExpression.getValue(any())).thenReturn(VALUE);
+
+    setField(databaseDisconnectDelegate, "designation", designationExpression);
+    setField(databaseDisconnectDelegate, "connectionService", connectionService);
+  }
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/DatabaseQueryDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/DatabaseQueryDelegateTest.java
@@ -1,0 +1,250 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.JSON_OBJECT;
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.folio.spring.test.mock.MockMvcConstant.PATH;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.camunda.bpm.model.bpmn.instance.FlowElement;
+import org.folio.rest.camunda.service.DatabaseConnectionService;
+import org.folio.rest.workflow.model.DatabaseQueryTask;
+import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DatabaseQueryDelegateTest {
+
+  private static final String QUERY = "query";
+
+  @Mock
+  private DatabaseConnectionService connectionService;
+
+  @Mock
+  private Connection connection;
+
+  @Mock
+  private Statement statement;
+
+  @Mock
+  private FlowElement flowElementBpmn;
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  private Expression designationExpression;
+
+  private Expression includeHeaderExpression;
+
+  private Expression inputVariablesExpression;
+
+  private Expression outputPathExpression;
+
+  private Expression outputVariableExpression;
+
+  private Expression queryExpression;
+
+  private Expression resultTypeExpression;
+
+  private ResultSet resultSet;
+
+  private ResultSetMetaData resultSetMetaData;
+
+  private ObjectMapper objectMapper;
+
+  @InjectMocks
+  private DatabaseQueryDelegate databaseQueryDelegate;
+
+  @BeforeEach
+  void beforeEach() {
+    designationExpression = mock(Expression.class);
+    includeHeaderExpression = mock(Expression.class);
+    inputVariablesExpression = mock(Expression.class);
+    outputPathExpression = mock(Expression.class);
+    outputVariableExpression = mock(Expression.class);
+    queryExpression = mock(Expression.class);
+    resultTypeExpression = mock(Expression.class);
+    resultSet = mock(ResultSet.class);
+    resultSetMetaData = mock(ResultSetMetaData.class);
+
+    objectMapper = new ObjectMapper();
+  }
+
+  @Test
+  void testExecuteWorksWithPositiveUpdateCount() throws Exception {
+    setupExecuteMocking();
+
+    when(connectionService.getConnection(anyString())).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+    when(statement.execute(anyString())).thenReturn(true);
+    when(statement.getUpdateCount()).thenReturn(1);
+
+    databaseQueryDelegate.execute(delegateExecution);
+
+    verify(statement).getUpdateCount();
+  }
+
+  @Test
+  void testExecuteWorksWithNegativeUpdateCountNullOutputPath() throws Exception {
+    setupExecuteMocking();
+
+    when(connectionService.getConnection(anyString())).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+    when(statement.execute(anyString())).thenReturn(true);
+    when(statement.getUpdateCount()).thenReturn(-1);
+    when(statement.getResultSet()).thenReturn(resultSet);
+    when(resultSet.getMetaData()).thenReturn(resultSetMetaData);
+    when(outputVariableExpression.getValue(any())).thenReturn(null);
+
+    setField(databaseQueryDelegate, "outputPath", null);
+    setField(databaseQueryDelegate, "outputVariable", outputVariableExpression);
+
+    databaseQueryDelegate.execute(delegateExecution);
+
+    verify(statement).getUpdateCount();
+
+    when(includeHeaderExpression.getValue(any())).thenReturn(null);
+
+    databaseQueryDelegate.execute(delegateExecution);
+
+    verify(statement, times(2)).getUpdateCount();
+
+    setField(databaseQueryDelegate, "includeHeader", null);
+
+    databaseQueryDelegate.execute(delegateExecution);
+
+    verify(statement, times(3)).getUpdateCount();
+  }
+
+  @Test
+  void testExecuteWorksWithNegativeUpdateCountWithOutputPath() throws Exception {
+    setupExecuteMocking();
+
+    when(connectionService.getConnection(anyString())).thenReturn(connection);
+    when(connection.createStatement()).thenReturn(statement);
+    when(statement.execute(anyString())).thenReturn(true);
+    when(statement.getUpdateCount()).thenReturn(-1);
+    when(statement.getResultSet()).thenReturn(resultSet);
+    when(outputVariableExpression.getValue(any())).thenReturn(null);
+    when(outputPathExpression.getValue(any())).thenReturn(PATH);
+
+    // Return a mocked enum that is private to the class using reflection.
+    Class<?>[] classes = databaseQueryDelegate.getClass().getDeclaredClasses();
+    for (int i = 0; i < classes.length; i++) {
+      if ("DatabaseResultTypeOp".equals(classes[i].getSimpleName())) {
+        Object[] enums = classes[i].getEnumConstants();
+        if (enums.length > 0) {
+          when(resultTypeExpression.getValue(any())).thenReturn(enums[0]);
+          break;
+        }
+      }
+    }
+
+    setField(databaseQueryDelegate, "outputPath", outputPathExpression);
+    setField(databaseQueryDelegate, "outputVariable", outputVariableExpression);
+
+    databaseQueryDelegate.execute(delegateExecution);
+
+    verify(statement).getUpdateCount();
+  }
+
+  @Test
+  void testExecuteThrowsException() throws JsonProcessingException, SQLException {
+    setupExecuteMocking();
+
+    doThrow(SQLException.class).when(connectionService).getConnection(anyString());
+
+    assertThrows(Exception.class, () -> {
+      databaseQueryDelegate.execute(delegateExecution);
+    });
+  }
+
+  @Test
+  void testSetIncludeHeaderWorks() {
+    setField(databaseQueryDelegate, "includeHeader", null);
+
+    databaseQueryDelegate.setIncludeHeader(includeHeaderExpression);
+    assertEquals(includeHeaderExpression, getField(databaseQueryDelegate, "includeHeader"));
+  }
+
+  @Test
+  void testSetOutputPathWorks() {
+    setField(databaseQueryDelegate, "outputPath", null);
+
+    databaseQueryDelegate.setOutputPath(outputPathExpression);
+    assertEquals(outputPathExpression, getField(databaseQueryDelegate, "outputPath"));
+  }
+
+  @Test
+  void testSetQueryWorks() {
+    setField(databaseQueryDelegate, "query", null);
+
+    databaseQueryDelegate.setQuery(queryExpression);
+    assertEquals(queryExpression, getField(databaseQueryDelegate, "query"));
+  }
+
+  @Test
+  void testSetResultTypeWorks() {
+    setField(databaseQueryDelegate, "resultType", null);
+
+    databaseQueryDelegate.setResultType(resultTypeExpression);
+    assertEquals(resultTypeExpression, getField(databaseQueryDelegate, "resultType"));
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(DatabaseQueryTask.class, databaseQueryDelegate.fromTask());
+  }
+
+  /**
+   * Provide common mocking behavior for the execute() method.
+   *
+   * @throws JsonProcessingException On JSON processing error.
+   */
+  private void setupExecuteMocking() throws JsonProcessingException {
+    final Set<EmbeddedVariable> inputs = new HashSet<>(List.of(new EmbeddedVariable()));
+
+    when(delegateExecution.getBpmnModelElementInstance()).thenReturn(flowElementBpmn);
+    when(flowElementBpmn.getName()).thenReturn(KEY);
+    when(designationExpression.getValue(any())).thenReturn(VALUE);
+    when(queryExpression.getValue(any())).thenReturn(QUERY);
+    when(includeHeaderExpression.getValue(any())).thenReturn(JSON_OBJECT);
+    when(inputVariablesExpression.getValue(any())).thenReturn(objectMapper.writeValueAsString(inputs));
+
+    setField(databaseQueryDelegate, "designation", designationExpression);
+    setField(databaseQueryDelegate, "connectionService", connectionService);
+    setField(databaseQueryDelegate, "includeHeader", includeHeaderExpression);
+    setField(databaseQueryDelegate, "outputPath", outputPathExpression);
+    setField(databaseQueryDelegate, "query", queryExpression);
+    setField(databaseQueryDelegate, "resultType", resultTypeExpression);
+    setField(databaseQueryDelegate, "inputVariables", inputVariablesExpression);
+    setField(databaseQueryDelegate, "objectMapper", objectMapper);
+  }
+}

--- a/src/test/java/org/folio/rest/camunda/delegate/EmailDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/EmailDelegateTest.java
@@ -1,0 +1,229 @@
+package org.folio.rest.camunda.delegate;
+
+import static org.folio.spring.test.mock.MockMvcConstant.KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.getField;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import jakarta.mail.internet.MimeMessage;
+import java.util.Arrays;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
+import org.camunda.bpm.engine.delegate.Expression;
+import org.camunda.bpm.model.bpmn.instance.FlowElement;
+import org.folio.rest.workflow.model.EmailTask;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+
+@ExtendWith(MockitoExtension.class)
+class EmailDelegateTest {
+
+  private static final String ATTACHMENT_PATH = "attachment_path";
+
+  private static final String INCLUDE_ATTACHMENT = "include_attachment";
+
+  private static final String MAIL_BCC = "mail_bcc";
+
+  private static final String MAIL_CC = "mail_cc";
+
+  private static final String MAIL_FROM = "mail_from";
+
+  private static final String MAIL_MARKUP = "mail_markup";
+
+  private static final String MAIL_SUBJECT = "mail_subject";
+
+  private static final String MAIL_TEXT = "mail_text";
+
+  private static final String MAIL_TO = "mail_to";
+
+  @Mock
+  private DelegateExecution delegateExecution;
+
+  @Mock
+  private JavaMailSender emailSender;
+
+  @Mock
+  private FlowElement flowElementBpmn;
+
+  @Mock
+  private MimeMessage mimeMessage;
+
+  private Expression attachmentPathExpression;
+
+  private Expression includeAttachmentExpression;
+
+  private Expression mailBccExpression;
+
+  private Expression mailCcExpression;
+
+  private Expression mailFromExpression;
+
+  private Expression mailMarkupExpression;
+
+  private Expression mailSubjectExpression;
+
+  private Expression mailTextExpression;
+
+  private Expression mailToExpression;
+
+  @InjectMocks
+  private EmailDelegate emailDelegate;
+
+  @BeforeEach
+  void beforeEach() {
+    attachmentPathExpression = mock(Expression.class);
+    includeAttachmentExpression = mock(Expression.class);
+    mailBccExpression = mock(Expression.class);
+    mailCcExpression = mock(Expression.class);
+    mailFromExpression = mock(Expression.class);
+    mailMarkupExpression = mock(Expression.class);
+    mailSubjectExpression = mock(Expression.class);
+    mailTextExpression = mock(Expression.class);
+    mailToExpression = mock(Expression.class);
+  }
+
+  @Test
+  void testExecuteWorks() throws Exception {
+    setupExecuteMocking();
+
+    emailDelegate.execute(delegateExecution);
+
+    verify(emailSender).send(any(MimeMessagePreparator.class));
+  }
+
+  @Test
+  void testSetAttachmentPathWorks() {
+    setField(emailDelegate, "attachmentPath", null);
+
+    emailDelegate.setAttachmentPath(attachmentPathExpression);
+    assertEquals(attachmentPathExpression, getField(emailDelegate, "attachmentPath"));
+  }
+
+  @Test
+  void testSetIncludeAttachmentWorks() {
+    setField(emailDelegate, "includeAttachment", null);
+
+    emailDelegate.setIncludeAttachment(includeAttachmentExpression);
+    assertEquals(includeAttachmentExpression, getField(emailDelegate, "includeAttachment"));
+  }
+
+  @Test
+  void testSetMailBccWorks() {
+    setField(emailDelegate, "mailBcc", null);
+
+    emailDelegate.setMailBcc(mailBccExpression);
+    assertEquals(mailBccExpression, getField(emailDelegate, "mailBcc"));
+  }
+
+  @Test
+  void testSetMailCcWorks() {
+    setField(emailDelegate, "mailCc", null);
+
+    emailDelegate.setMailCc(mailCcExpression);
+    assertEquals(mailCcExpression, getField(emailDelegate, "mailCc"));
+  }
+
+  @Test
+  void testSetMailFromWorks() {
+    setField(emailDelegate, "mailFrom", null);
+
+    emailDelegate.setMailFrom(mailFromExpression);
+    assertEquals(mailFromExpression, getField(emailDelegate, "mailFrom"));
+  }
+
+  @Test
+  void testSetMailMarkupWorks() {
+    setField(emailDelegate, "mailMarkup", null);
+
+    emailDelegate.setMailMarkup(mailMarkupExpression);
+    assertEquals(mailMarkupExpression, getField(emailDelegate, "mailMarkup"));
+  }
+
+  @Test
+  void testSetMailSubjectWorks() {
+    setField(emailDelegate, "mailSubject", null);
+
+    emailDelegate.setMailSubject(mailSubjectExpression);
+    assertEquals(mailSubjectExpression, getField(emailDelegate, "mailSubject"));
+  }
+
+  @Test
+  void testSetMailTextWorks() {
+    setField(emailDelegate, "mailText", null);
+
+    emailDelegate.setMailText(mailTextExpression);
+    assertEquals(mailTextExpression, getField(emailDelegate, "mailText"));
+  }
+
+  @Test
+  void testSetMailToWorks() {
+    setField(emailDelegate, "mailTo", null);
+
+    emailDelegate.setMailTo(mailToExpression);
+    assertEquals(mailToExpression, getField(emailDelegate, "mailTo"));
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(EmailTask.class, emailDelegate.fromTask());
+  }
+
+  /**
+   * Provide common mocking behavior for the execute() method.
+   *
+   * @throws JsonProcessingException On JSON processing error.
+   */
+  private void setupExecuteMocking() throws JsonProcessingException {
+    when(delegateExecution.getBpmnModelElementInstance()).thenReturn(flowElementBpmn);
+    when(flowElementBpmn.getName()).thenReturn(KEY);
+    when(attachmentPathExpression.getValue(any())).thenReturn(ATTACHMENT_PATH);
+    when(includeAttachmentExpression.getValue(any())).thenReturn(INCLUDE_ATTACHMENT);
+    when(mailBccExpression.getValue(any())).thenReturn(MAIL_BCC);
+    when(mailCcExpression.getValue(any())).thenReturn(MAIL_CC);
+    when(mailFromExpression.getValue(any())).thenReturn(MAIL_FROM);
+    when(mailMarkupExpression.getValue(any())).thenReturn(MAIL_MARKUP);
+    when(mailSubjectExpression.getValue(any())).thenReturn(MAIL_SUBJECT);
+    when(mailTextExpression.getValue(any())).thenReturn(MAIL_TEXT);
+    when(mailToExpression.getValue(any())).thenReturn(MAIL_TO);
+
+    doAnswer(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocation) throws Throwable {
+        Object[] args = invocation.getArguments();
+
+        if (args.length == 1) {
+          MimeMessagePreparator preparator = (MimeMessagePreparator) args[0];
+          preparator.prepare(mimeMessage);
+        }
+
+        return null;
+      }
+    }).when(emailSender).send(any(MimeMessagePreparator.class));
+
+    setField(emailDelegate, "emailSender", emailSender);
+    setField(emailDelegate, "attachmentPath", attachmentPathExpression);
+    setField(emailDelegate, "includeAttachment", includeAttachmentExpression);
+    setField(emailDelegate, "mailBcc", mailBccExpression);
+    setField(emailDelegate, "mailCc", mailCcExpression);
+    setField(emailDelegate, "mailFrom", mailFromExpression);
+    setField(emailDelegate, "mailMarkup", mailMarkupExpression);
+    setField(emailDelegate, "mailSubject", mailSubjectExpression);
+    setField(emailDelegate, "mailText", mailTextExpression);
+    setField(emailDelegate, "mailTo", mailToExpression);
+  }
+
+}


### PR DESCRIPTION
Switch to use `@Spy` instead of `@InjectMocks` in most cases to avoid problems where Mockito has conflicts when abstract-classes or interfaces are used multiple times with `@Mock`.
Add and use `@BeforeEach` in the case where `@InjectMocks` seems to be better served.

The delegate unit tests exposed a design bug where the abstract interfaces are calling a getter without checking if the value is NULL for the default abstract implementation.
There is a "has" function added to child abstract implementation that provides the expected safety check.
Move this child abstract class "has" method into the parent abstract class and update the default abstract getter method to call this "has" method.

This is intended to be changed into a PR into the base branch or the staging branch at the start of the next sprint.
The merge into master is only temporary and is intended only as a way to show this PR.

Re-design functional logic to address `S3776` reported by sonarcloud in some extreme cases.

This contains structural code clean up changes and is being merged into the base branch to use as a starting point.