### PR TITLE
MODCAMUNDA-9: The delete deployment method should pass true in the cascade parameter.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
@@ -51,7 +51,7 @@ public class CamundaApiService {
 
     ProcessEngine processEngine = ProcessEngines.getDefaultProcessEngine();
     RepositoryService repositoryService = processEngine.getRepositoryService();
-    repositoryService.deleteDeployment(workflow.getDeploymentId());
+    repositoryService.deleteDeployment(workflow.getDeploymentId(), true);
 
     workflow.setActive(false);
     workflow.setDeploymentId(null);


### PR DESCRIPTION
Resolves [MODCAMUNDA-9](https://folio-org.atlassian.net/browse/MODCAMUNDA-9)

Setting cascade to true allows for deletion of workflow even when there are incidents.