### PR TITLE
Improve Module Descriptor and application.yml to favor auto-deployment.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -418,6 +418,11 @@
         "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
       },
+      { "name": "CAMUNDA_BPM_ADMINUSER_EMAIL", "value": "admin@localhost", "description": "The e-mail address of the Camunda administration user." },
+      { "name": "CAMUNDA_BPM_ADMINUSER_ID", "value": "admin", "description": "The account name of the Camunda administration user." },
+      { "name": "CAMUNDA_BPM_ADMINUSER_PASSWORD", "value": "admin", "description": "The password of the Camunda administration user." },
+      { "name": "CAMUNDA_BPM_DATABASE_SCHEMAUPDATE", "value": "false", "description": "If Camunda should auto-update the BPM database schema." },
+      { "name": "CAMUNDA_BPM_METRICS", "value": "false", "description": "Enable or disable Camunda metrics by default." },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },
       { "name": "DB_USERNAME", "value": "folio_admin" },
@@ -426,7 +431,16 @@
       { "name": "DB_QUERYTIMEOUT", "value": "60000" },
       { "name": "DB_CHARSET", "value": "UTF-8" },
       { "name": "DB_MAXPOOLSIZE", "value": "16" },
-      { "name": "OKAPI_URL", "value": "http://10.0.2.15:9130", "description": "The URL to the OKAPI service." }
+      { "name": "EVENT_QUEUE_NAME", "value": "event.queue", "description": "The ActiveMQ event queue name." },
+      { "name": "OKAPI_URL", "value": "http://10.0.2.15:9130", "description": "The URL to the OKAPI service." },
+      { "name": "SERVER_PORT", "value": "8081", "description": "The port to listen on that must match the PortBindings." },
+      { "name": "SERVER_SERVLET_CONTEXTPATH", "value": "/", "description": "The context path, or base path, to host at." },
+      { "name": "SPRING_ACTIVEMQ_BROKERURL", "value": "tcp://localhost:61616", "description": "The URL to the ActiveMQ server." },
+      { "name": "SPRING_FLYWAY_ENABLED", "value": "false", "description": "Database migration support via Spring Flyway." },
+      { "name": "SPRING_JPA_HIBERNATE_DDLAUTO", "value": "update", "description": "Auto-configure database on startup." },
+      { "name": "TENANT_DEFAULTTENANT", "value": "diku", "description": "The name of the default tenant to use." },
+      { "name": "TENANT_FORCETENANT", "value": "false", "description": "Forcibly add or overwrite the tenant name using the default tenant." },
+      { "name": "TENANT_INITIALIZEDEFAULTTENANT", "value": "true", "description": "Perform initial auto-creation of tenant in the DB (schema, tables, etc..)." }
     ]
   }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -13,7 +13,7 @@ logging:
       springframework: INFO
 
 server:
-  port: 9000
+  port: 8081
   servlet:
     context-path: /
     encoding:
@@ -55,7 +55,7 @@ spring:
     password: ${DB_PASSWORD:folio_admin}
 
   flyway:
-    enabled: true
+    enabled: false
     encoding: UTF-8
 
   h2:
@@ -71,7 +71,7 @@ spring:
 
     properties.hibernate.jdbc.lob.non_contextual_creation: true
     generate-ddl: false
-    hibernate.ddl-auto: none
+    hibernate.ddl-auto: update
     open-in-view: true
     show-sql: false
 


### PR DESCRIPTION
Expose additional notable environment variables in the Module Descriptor. The default settings provided, except for maybe the admin account name and associated passwords, should represent the sane default values for auto-deployment.

The ActiveMQ may be removed in the future but for now it is in use. Expose the settings such that if a non-local ActiveMQ is used, then it can be appropriately configured.

The server port should not change from 8081 during deployment without additional module descriptor changes. Document the server port setting as a practice.
The server context path is also exposed as a practice.

The Flyway should be disabled by default for auto-deployment (in general).

Expose the tenant information to make the required changes more obvious should a non-default tenant be used.

Expose notable Camunda BPM settings that may relate to or be influence by deployment.

The default port number is now set to 8081 rather than 9000.

Flyway is now disabled by default.

The Hibernate DDL auto is now set to `update` by default.