### PR TITLE
The camunda database schema update (CAMUNDA_BPM_DATABASE_SCHEMAUPDATE) likely must be true by default.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -421,7 +421,7 @@
       { "name": "CAMUNDA_BPM_ADMINUSER_EMAIL", "value": "admin@localhost", "description": "The e-mail address of the Camunda administration user." },
       { "name": "CAMUNDA_BPM_ADMINUSER_ID", "value": "admin", "description": "The account name of the Camunda administration user." },
       { "name": "CAMUNDA_BPM_ADMINUSER_PASSWORD", "value": "admin", "description": "The password of the Camunda administration user." },
-      { "name": "CAMUNDA_BPM_DATABASE_SCHEMAUPDATE", "value": "false", "description": "If Camunda should auto-update the BPM database schema." },
+      { "name": "CAMUNDA_BPM_DATABASE_SCHEMAUPDATE", "value": "true", "description": "If Camunda should auto-update the BPM database schema." },
       { "name": "CAMUNDA_BPM_METRICS", "value": "false", "description": "Enable or disable Camunda metrics by default." },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -102,7 +102,7 @@ camunda:
   bpm:
     auto-deployment-enabled: false
     database:
-      schema-update: false
+      schema-update: true
     filter:
       create: All Tasks
     admin-user:


### PR DESCRIPTION
The mod-camunda is not deploying correctly by default. The console logs state that `CAMUNDA_BPM_DATABASE_SCHEMAUPDATE` might need to be set to `true` or `create-drop`.