### PR TITLE
Change default schema-scripts from H2 to Postgresql.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -157,13 +157,23 @@ tenant:
   # https://github.com/camunda/camunda-bpm-platform/tree/master/engine/src/main/resources/org/camunda/bpm/engine/db/create
   # be sure to match datasource platform
   schema-scripts:
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.engine.sql
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.history.sql
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.identity.sql
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.case.engine.sql
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.case.history.sql
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.decision.engine.sql
-    - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.decision.history.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.engine.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.history.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.identity.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.case.engine.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.case.history.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.decision.engine.sql
+    - classpath:/org/camunda/bpm/engine/db/create/activiti.postgres.create.decision.history.sql
+
+  # H2 schema scripts.
+  #schema-scripts:
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.engine.sql
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.history.sql
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.identity.sql
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.case.engine.sql
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.case.history.sql
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.decision.engine.sql
+  #  - classpath:/org/camunda/bpm/engine/db/create/activiti.h2.create.decision.history.sql
 
 okapi.url: ${OKAPI_URL:http://localhost:9130}
 


### PR DESCRIPTION
The database is set to PostgreSQL by default but the `schema-scripts` are still set to H2. Keep the H2 for easy uncommenting during local development but set the default to PostgreSQL.