### PR TITLE
MODCAMUNDA-13: Get the InputTask working in its most basic form.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
@@ -20,14 +20,11 @@ public abstract class AbstractDelegate implements JavaDelegate {
   }
 
   /**
-   * Get the delegate name.
-   *
-   * This is used for functions that do not have the delegate execution data.
-   * The delegate name is derived from the class name.
+   * Get the delegate class name.
    *
    * @return The delegate name.
    */
-  protected String getDelegateName() {
+  protected String getDelegateClass() {
     String simpleName = getClass().getSimpleName();
 
     return simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
@@ -35,9 +32,6 @@ public abstract class AbstractDelegate implements JavaDelegate {
 
   /**
    * Get the delegate name.
-   *
-   * This is the preferred method to get the delegate name but requires access to the delegate execution.
-   * The delegate execution data is used to derive the delegate name.
    *
    * @param execution The delegate execution data.
    *
@@ -53,7 +47,7 @@ public abstract class AbstractDelegate implements JavaDelegate {
    * @return The formatted expression string.
    */
   public String getExpression() {
-    return String.format("${%s}", getDelegateName());
+    return String.format("${%s}", getDelegateClass());
   }
 
   /**
@@ -97,17 +91,6 @@ public abstract class AbstractDelegate implements JavaDelegate {
    */
   protected void determineEndTime(DelegateExecution execution, long startTime) {
     getLogger().info("{} finished in {} milliseconds", getDelegateName(execution), (System.nanoTime() - startTime) / (double) 1000000);
-  }
-
-  /**
-   * Log that the delegate has started.
-   *
-   * @param execution The delegate execution data.
-   *
-   * @param startTime The time the process started.
-   */
-  protected void logExecutionStart(DelegateExecution execution) {
-    getLogger().info("{} started", getDelegateName(execution));
   }
 
 }

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
@@ -1,6 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.JavaDelegate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,26 +11,103 @@ public abstract class AbstractDelegate implements JavaDelegate {
 
   private final Logger log;
 
+  @Autowired
+  protected ObjectMapper objectMapper;
+
   AbstractDelegate() {
     // The logger is non-static to ensure that the implementing class name is used for the logger.
     log = LoggerFactory.getLogger(this.getClass());
   }
 
-  @Autowired
-  protected ObjectMapper objectMapper;
-
-  public String getExpression() {
+  /**
+   * Get the delegate name.
+   *
+   * This is used for functions that do not have the delegate execution data.
+   * The delegate name is derived from the class name.
+   *
+   * @return The delegate name.
+   */
+  protected String getDelegateName() {
     String simpleName = getClass().getSimpleName();
-    String delegateName = simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
-    return String.format("${%s}", delegateName);
+
+    return simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
   }
 
+  /**
+   * Get the delegate name.
+   *
+   * This is the preferred method to get the delegate name but requires access to the delegate execution.
+   * The delegate execution data is used to derive the delegate name.
+   *
+   * @param execution The delegate execution data.
+   *
+   * @return The delegate name.
+   */
+  protected String getDelegateName(DelegateExecution execution) {
+    return execution.getBpmnModelElementInstance().getName();
+  }
+
+  /**
+   * Get the expression.
+   *
+   * @return The formatted expression string.
+   */
+  public String getExpression() {
+    return String.format("${%s}", getDelegateName());
+  }
+
+  /**
+   * Get the logger.
+   *
+   * @return The logger for this class.
+   */
   public Logger getLogger() {
     return log;
   }
 
+  /**
+   * Get the Object Mapper.
+   *
+   * @return The Object Mapper for this class.
+   */
   public ObjectMapper getObjectMapper() {
     return objectMapper;
+  }
+
+  /**
+   * Determine the start time of the query and print log.
+   *
+   * @param execution The delegate execution data.
+   * @param args additional string arguments to pass.
+   *
+   * @return The start time.
+   */
+  protected long determineStartTime(DelegateExecution execution, Object ...args) {
+    getLogger().info("{} {} started", getDelegateName(execution), args);
+
+    return System.nanoTime();
+  }
+
+  /**
+   * Given the start time, determine the total time spent.
+   *
+   * @param execution The delegate execution data.
+   *
+   * @param startTime The time the process started.
+   */
+  protected void determineEndTime(DelegateExecution execution, long startTime) {
+    getLogger().info("{} finished in {} milliseconds", getDelegateName(execution), (System.nanoTime() - startTime) / (double) 1000000);
+  }
+
+  /**
+   * Log that the delegate has started.
+   *
+   * @param execution The delegate execution data.
+   *
+   * @param startTime The time the process started.
+   */
+  protected void logExecutionStart(DelegateExecution execution) {
+    getLogger().info("{} started", getDelegateName(execution));
   }
 
 }

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractRuntimeDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractRuntimeDelegate.java
@@ -7,5 +7,4 @@ public abstract class AbstractRuntimeDelegate extends AbstractDelegate {
 
   @Autowired
   protected RuntimeService runtimeService;
-
 }

--- a/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
@@ -20,7 +20,6 @@ import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.enums.CompressFileContainer;
 import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.model.CompressFileTask;
@@ -51,11 +50,7 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     String sourcePathTemplate = this.source.getValue(execution).toString();
     String destinationPathTemplate = this.destination.getValue(execution).toString();
@@ -165,8 +160,7 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
       }
     }
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setSource(Expression source) {

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
@@ -1,10 +1,8 @@
 package org.folio.rest.camunda.delegate;
 
 import java.util.Properties;
-
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.model.DatabaseConnectionTask;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
@@ -19,11 +17,7 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     String urlValue = this.url.getValue(execution).toString();
     String key = this.designation.getValue(execution).toString();
@@ -34,8 +28,7 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
 
     connectionService.createPool(key, urlValue, info);
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setUrl(Expression url) {

--- a/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
@@ -9,7 +9,6 @@ import java.util.Objects;
 import java.util.Optional;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.model.EmailTask;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
@@ -50,11 +49,7 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     String subjectTemplate = this.mailSubject.getValue(execution).toString();
     String textTemplate = this.mailText.getValue(execution).toString();
@@ -135,8 +130,7 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
 
     emailSender.send(preparator);
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setMailTo(Expression mailTo) {

--- a/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
@@ -1,5 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
+import freemarker.cache.StringTemplateLoader;
+import freemarker.template.Configuration;
 import java.io.BufferedReader;
 import java.io.File;
 import java.nio.charset.StandardCharsets;
@@ -11,13 +13,9 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-
-import freemarker.cache.StringTemplateLoader;
-import freemarker.template.Configuration;
 import org.apache.commons.io.FileUtils;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.FileTask;
 import org.springframework.context.annotation.Scope;
@@ -42,13 +40,8 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
-
-    getLogger().info("{} {} started", delegateName, fileOp);
+    final FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
+    final long startTime = determineStartTime(execution, fileOp);
 
     String pathTemplate = this.path.getValue(execution).toString();
     String lineTemplate = this.line != null ? this.line.getValue(execution).toString() : "0";
@@ -182,8 +175,7 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
         break;
     }
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} {} finished in {} milliseconds", delegateName, fileOp, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setPath(Expression path) {

--- a/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
@@ -10,7 +10,6 @@ import org.apache.commons.vfs2.Selectors;
 import org.apache.commons.vfs2.VFS;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.enums.SftpOp;
 import org.folio.rest.workflow.model.FtpTask;
 import org.springframework.context.annotation.Scope;
@@ -38,11 +37,7 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     String originPathValue = this.originPath.getValue(execution).toString();
 
@@ -125,10 +120,7 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
         break;
     }
 
-
-
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setOriginPath(Expression originPath) {

--- a/src/main/java/org/folio/rest/camunda/delegate/Input.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/Input.java
@@ -65,7 +65,7 @@ public interface Input {
    * @throws JsonProcessingException Failed to process JSON.
    */
   private void defaultGetInputsLoop(EmbeddedVariable variable, String key, VariableType type, Object value, Map<String, Object> inputs) throws JsonProcessingException {
-    if (!variable.isSpin()) {
+    if (Boolean.FALSE.equals(variable.getSpin())) {
       inputs.put(key, value);
       return;
     }

--- a/src/main/java/org/folio/rest/camunda/delegate/InputDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/InputDelegate.java
@@ -1,28 +1,33 @@
 package org.folio.rest.camunda.delegate;
 
 import org.camunda.bpm.engine.delegate.DelegateExecution;
-import org.folio.rest.workflow.model.DatabaseDisconnectTask;
+import org.folio.rest.workflow.model.RequestTask;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 @Service
 @Scope("prototype")
-public class DatabaseDisconnectDelegate extends AbstractDatabaseDelegate {
+public class InputDelegate extends AbstractWorkflowIODelegate {
+
+  @Value("${okapi.url}")
+  private String okapiUrl;
+
+  @Autowired
+  public InputDelegate() {
+  }
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
     final long startTime = determineStartTime(execution);
-
-    String key = this.designation.getValue(execution).toString();
-
-    connectionService.destroyConnection(key);
 
     determineEndTime(execution, startTime);
   }
 
   @Override
   public Class<?> fromTask() {
-    return DatabaseDisconnectTask.class;
+    return RequestTask.class;
   }
 
 }

--- a/src/main/java/org/folio/rest/camunda/delegate/Output.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/Output.java
@@ -43,7 +43,7 @@ public interface Output {
     }
 
     VariableType type = variable.getType();
-    Object value = variable.isSpin()
+    Object value = Boolean.TRUE.equals(variable.getSpin())
       ? JSON(getObjectMapper().writeValueAsString(output))
       : Variables.objectValue(output, variable.getAsTransient()).create();
 

--- a/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
@@ -1,18 +1,15 @@
 package org.folio.rest.camunda.delegate;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
-
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.folio.rest.workflow.model.ProcessorTask;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 @Service
 @Scope("prototype")
@@ -25,11 +22,7 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     EmbeddedProcessor processorValue = objectMapper.readValue(this.processor.getValue(execution).toString(), EmbeddedProcessor.class);
 
@@ -45,8 +38,7 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
 
     setOutput(execution, output);
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setProcessor(Expression processor) {

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -9,7 +9,6 @@ import java.util.Optional;
 import java.util.Set;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.folio.rest.workflow.dto.Request;
 import org.folio.rest.workflow.enums.VariableType;
 import org.folio.rest.workflow.model.EmbeddedVariable;
@@ -45,11 +44,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     Request requestValue = objectMapper.readValue(this.request.getValue(execution).toString(), Request.class);
 
@@ -125,8 +120,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
       }
     });
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setRequest(Expression request) {

--- a/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
@@ -2,20 +2,17 @@ package org.folio.rest.camunda.delegate;
 
 import static org.camunda.spin.Spin.JSON;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import java.util.List;
 import java.util.Map;
-
 import org.camunda.bpm.engine.delegate.DelegateExecution;
 import org.camunda.bpm.engine.delegate.Expression;
-import org.camunda.bpm.model.bpmn.instance.FlowElement;
 import org.camunda.spin.json.SpinJsonNode;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
-
-import com.fasterxml.jackson.core.type.TypeReference;
 
 @Service
 @Scope("prototype")
@@ -33,17 +30,13 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
 
   @Override
   public void execute(DelegateExecution execution) throws Exception {
-    long startTime = System.nanoTime();
-    FlowElement bpmnModelElement = execution.getBpmnModelElementInstance();
-    String delegateName = bpmnModelElement.getName();
-
-    getLogger().info("{} started", delegateName);
+    final long startTime = determineStartTime(execution);
 
     getLogger().info("loading initial context");
 
     Map<String, Object> context = objectMapper.readValue(initialContext.getValue(execution).toString(),
-        new TypeReference<Map<String, Object>>() {
-        });
+      new TypeReference<Map<String, Object>>() {
+    });
 
     for (Map.Entry<String, Object> entry : context.entrySet()) {
       SpinJsonNode node = JSON(objectMapper.writeValueAsString(entry.getValue()));
@@ -59,8 +52,8 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
     getLogger().info("loading scripts");
 
     List<EmbeddedProcessor> processorsValue = objectMapper.readValue(this.processors.getValue(execution).toString(),
-        new TypeReference<List<EmbeddedProcessor>>() {
-        });
+      new TypeReference<List<EmbeddedProcessor>>() {
+    });
 
     for (EmbeddedProcessor processor : processorsValue) {
       String extension = processor.getScriptType().getExtension();
@@ -70,8 +63,7 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
       getLogger().info("{}: {}", processor.getFunctionName(), processor.getCode());
     }
 
-    long endTime = System.nanoTime();
-    getLogger().info("{} finished in {} milliseconds", delegateName, (endTime - startTime) / (double) 1000000);
+    determineEndTime(execution, startTime);
   }
 
   public void setInitialContext(Expression initialContext) {

--- a/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
+++ b/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
@@ -189,6 +189,7 @@ public class BpmnModelFactory {
               break;
             case NONE:
             case SIMPLE:
+              break;
             default:
               logger.warn("Start Event named {} has an unknown setup type of {}.", node.getName(), setup);
               break;
@@ -407,7 +408,7 @@ public class BpmnModelFactory {
             .filter(df -> Expression.class.isAssignableFrom(df.getType()))
             .map(df -> FieldUtils.getDeclaredField(node.getClass(), df.getName(), true)).forEach(f -> {
               try {
-                Object value = f.get(node);
+                Object value = f == null ? null : f.get(node);
                 if (Objects.nonNull(value)) {
                   CamundaField field = model.newInstance(CamundaField.class);
                   field.setCamundaName(f.getName());
@@ -445,6 +446,8 @@ public class BpmnModelFactory {
         scripts.addAll(getProcessorScripts(((Branch) node).getNodes()));
       } else if (node instanceof Subprocess) {
         scripts.addAll(getProcessorScripts(((Subprocess) node).getNodes()));
+      } else if (node instanceof Task) {
+        logger.warn("Processor Script named {} is a non-processor task.", node.getName());
       }
       else {
         logger.warn("Processor Script named {} is of an unknown type.", node.getName());

--- a/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
@@ -19,7 +19,7 @@ public class CamundaApiService {
   private BpmnModelFactory bpmnModelFactory;
 
   public Workflow deployWorkflow(Workflow workflow, String tenant) throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
-    if (workflow.isActive()) {
+    if (Boolean.TRUE.equals(workflow.getActive())) {
       throw new WorkflowAlreadyActiveException(workflow.getId());
     }
 
@@ -31,10 +31,10 @@ public class CamundaApiService {
     RepositoryService repositoryService = processEngine.getRepositoryService();
 
     Deployment deployment = repositoryService.createDeployment().name(workflow.getName())
-        .addModelInstance(workflow.getName().replace(" ", "") + ".bpmn", modelInstance)
-        .source("mod-workflow")
-        .tenantId(tenant)
-        .deploy();
+      .addModelInstance(workflow.getName().replace(" ", "") + ".bpmn", modelInstance)
+      .source("mod-workflow")
+      .tenantId(tenant)
+      .deploy();
 
     String deploymentId = deployment.getId();
 
@@ -45,7 +45,7 @@ public class CamundaApiService {
   }
 
   public Workflow undeployWorkflow(Workflow workflow) {
-    if (!workflow.isActive()) {
+    if (Boolean.FALSE.equals(workflow.getActive())) {
       return workflow;
     }
 

--- a/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
@@ -1,19 +1,27 @@
 package org.folio.rest.camunda.service;
 
+import org.camunda.bpm.engine.AuthorizationException;
+import org.camunda.bpm.engine.ParseException;
 import org.camunda.bpm.engine.ProcessEngine;
 import org.camunda.bpm.engine.ProcessEngines;
 import org.camunda.bpm.engine.RepositoryService;
+import org.camunda.bpm.engine.exception.NotFoundException;
+import org.camunda.bpm.engine.exception.NotValidException;
 import org.camunda.bpm.engine.repository.Deployment;
 import org.camunda.bpm.model.bpmn.Bpmn;
 import org.camunda.bpm.model.bpmn.BpmnModelInstance;
 import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.model.Workflow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CamundaApiService {
+
+  private final static Logger logger = LoggerFactory.getLogger(CamundaApiService.class);
 
   @Autowired
   private BpmnModelFactory bpmnModelFactory;
@@ -30,16 +38,24 @@ public class CamundaApiService {
     ProcessEngine processEngine = ProcessEngines.getDefaultProcessEngine();
     RepositoryService repositoryService = processEngine.getRepositoryService();
 
-    Deployment deployment = repositoryService.createDeployment().name(workflow.getName())
-      .addModelInstance(workflow.getName().replace(" ", "") + ".bpmn", modelInstance)
-      .source("mod-workflow")
-      .tenantId(tenant)
-      .deploy();
+    try {
+      Deployment deployment = repositoryService.createDeployment().name(workflow.getName())
+        .addModelInstance(workflow.getName().replace(" ", "") + ".bpmn", modelInstance)
+        .source("mod-workflow")
+        .tenantId(tenant).deploy();
 
-    String deploymentId = deployment.getId();
+      String deploymentId = deployment.getId();
 
-    workflow.setActive(true);
-    workflow.setDeploymentId(deploymentId);
+      workflow.setActive(true);
+      workflow.setDeploymentId(deploymentId);
+    } catch (NotFoundException | NotValidException | ParseException | AuthorizationException e) {
+      // TODO: find a way to write the stream to the logger rather than using System.out.
+      if (logger.isDebugEnabled()) {
+        Bpmn.writeModelToStream(System.out, modelInstance);
+      }
+
+      throw e;
+    }
 
     return workflow;
   }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -12,6 +12,9 @@ logging:
       hibernate: INFO
       springframework: INFO
 
+    # Enable logging of BPMN if activation fails.
+    #org.folio.rest.camunda.service.CamundaApiService: DEBUG
+
 server:
   port: 8081
   servlet:

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseOutputDelegateTest.java
@@ -84,7 +84,7 @@ class AbstractDatabaseOutputDelegateTest {
     assertEquals(embeddedVariable.getKey(), responseVariable.getKey());
     assertEquals(embeddedVariable.getAsJson(), responseVariable.getAsJson());
     assertEquals(embeddedVariable.getAsTransient(), responseVariable.getAsTransient());
-    assertEquals(embeddedVariable.isSpin(), responseVariable.isSpin());
+    assertEquals(Boolean.TRUE.equals(embeddedVariable.getSpin()), Boolean.TRUE.equals(responseVariable.getSpin()));
     assertEquals(embeddedVariable.getType(), responseVariable.getType());
   }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
@@ -59,7 +59,7 @@ class AbstractWorkflowIODelegateTest {
     assertEquals(embeddedVariable.getKey(), responseVariable.getKey());
     assertEquals(embeddedVariable.getAsJson(), responseVariable.getAsJson());
     assertEquals(embeddedVariable.getAsTransient(), responseVariable.getAsTransient());
-    assertEquals(embeddedVariable.isSpin(), responseVariable.isSpin());
+    assertEquals(Boolean.TRUE.equals(embeddedVariable.getSpin()), Boolean.TRUE.equals(responseVariable.getSpin()));
     assertEquals(embeddedVariable.getType(), responseVariable.getType());
   }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
@@ -64,7 +64,7 @@ class AbstractWorkflowInputDelegateTest {
       assertEquals(embeddedVariable.getKey(), ev.getKey());
       assertEquals(embeddedVariable.getAsJson(), ev.getAsJson());
       assertEquals(embeddedVariable.getAsTransient(), ev.getAsTransient());
-      assertEquals(embeddedVariable.isSpin(), ev.isSpin());
+      assertEquals(Boolean.TRUE.equals(embeddedVariable.getSpin()), Boolean.TRUE.equals(ev.getSpin()));
       assertEquals(embeddedVariable.getType(), ev.getType());
     });
   }

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
@@ -56,7 +56,7 @@ class AbstractWorkflowOutputDelegateTest {
     assertEquals(embeddedVariable.getKey(), responseVariable.getKey());
     assertEquals(embeddedVariable.getAsJson(), responseVariable.getAsJson());
     assertEquals(embeddedVariable.getAsTransient(), responseVariable.getAsTransient());
-    assertEquals(embeddedVariable.isSpin(), responseVariable.isSpin());
+    assertEquals(Boolean.TRUE.equals(embeddedVariable.getSpin()), Boolean.TRUE.equals(responseVariable.getSpin()));
     assertEquals(embeddedVariable.getType(), responseVariable.getType());
   }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
@@ -98,8 +98,8 @@ class ProcessorDelegateTest {
 
       delegate.execute(execution);
 
-      verify(execution, times(1)).getBpmnModelElementInstance();
-      verify(element, times(1)).getName();
+      verify(execution, times(2)).getBpmnModelElementInstance();
+      verify(element, times(2)).getName();
       verify(processor, times(1)).getValue(any(DelegateExecution.class));
       verify(objectMapper, times(1)).readValue(processorValue, EmbeddedProcessor.class);
       verify(objectMapper, times(1)).readValue(eq(inputVariablesValue), any(TypeReference.class));

--- a/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
@@ -81,7 +81,7 @@ class SetupDelegateTest {
 
       delegate.execute(execution);
 
-      verify(element, times(1)).getName();
+      verify(element, times(2)).getName();
       verify(initialContext, times(1)).getValue(any(DelegateExecution.class));
       verify(processors, times(1)).getValue(any(DelegateExecution.class));
       verify(objectMapper, times(1)).readValue(eq(initialContextValue), any(TypeReference.class));

--- a/src/test/java/org/folio/rest/camunda/service/CamundaApiServiceTest.java
+++ b/src/test/java/org/folio/rest/camunda/service/CamundaApiServiceTest.java
@@ -89,7 +89,7 @@ class CamundaApiServiceTest {
       Workflow result = camundaApiService.deployWorkflow(workflow, TENANT);
 
       assertNotNull(result);
-      assertTrue(result.isActive());
+      assertTrue(Boolean.TRUE.equals(result.getActive()));
       assertEquals("deploymentId", result.getDeploymentId());
 
       verify(bpmnModelFactory).fromWorkflow(workflow);
@@ -116,7 +116,7 @@ class CamundaApiServiceTest {
       Workflow result = camundaApiService.undeployWorkflow(workflow);
 
       assertNotNull(result);
-      assertFalse(result.isActive());
+      assertFalse(Boolean.TRUE.equals(result.getActive()));
       assertNull(result.getDeploymentId());
 
       verify(repositoryService).deleteDeployment("deploymentId", true);
@@ -131,7 +131,7 @@ class CamundaApiServiceTest {
       Workflow result = camundaApiService.undeployWorkflow(workflow);
 
       assertNotNull(result);
-      assertFalse(result.isActive());
+      assertFalse(Boolean.TRUE.equals(result.getActive()));
       assertNull(result.getDeploymentId());
 
       verify(repositoryService, never()).deleteDeployment(anyString(), anyBoolean());

--- a/src/test/java/org/folio/rest/camunda/utility/Parameters.java
+++ b/src/test/java/org/folio/rest/camunda/utility/Parameters.java
@@ -30,7 +30,7 @@ class Parameters<I, O> {
    * @param <O>      generic output
    * @param input    provided to use when calling method to test
    * @param expected output to make assertions against
-   * @return
+   * @return typed Parameter
    */
   public static <I, O> Parameters<I, O> of(I input, O expected) {
     return new Parameters<I, O>(input, expected);


### PR DESCRIPTION
[MODCAMUNDA-13](https://folio-org.atlassian.net/browse/MODCAMUNDA-13)

This does not yet have the form fields added.
The task has been tested activate, run, and complete without incident.

The project is updated to reflect the Workflow Components changes.

This removes some of the redundant code and relocates it into the abstract class for reducing repeated code.

This also adds support for logging the BPMN on error during activation via: `org.folio.rest.camunda.service.CamundaApiService`.