### PR TITLE
MODCAMUNDA-3: Clean up trailing slash work-around.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/controller/WorkflowController.java
+++ b/src/main/java/org/folio/rest/camunda/controller/WorkflowController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
 @RestController
-@RequestMapping({"/workflow-engine/workflows", "/workflow-engine/workflows/"})
+@RequestMapping("/workflow-engine/workflows")
 public class WorkflowController {
 
   private CamundaApiService camundaApiService;
@@ -25,14 +25,14 @@ public class WorkflowController {
     this.camundaApiService = camundaApiService;
   }
 
-  @PostMapping(value = {"/activate", "/activate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @PostMapping(value = "/activate", produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow activateWorkflow(@RequestBody Workflow workflow, @TenantHeader String tenant)
       throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
     log.debug("Activating Workflow: {}", workflow == null ? null : workflow.getId());
     return camundaApiService.deployWorkflow(workflow, tenant);
   }
 
-  @PostMapping(value = {"/deactivate", "/deactivate/"}, produces = { MediaType.APPLICATION_JSON_VALUE })
+  @PostMapping(value = "/deactivate", produces = { MediaType.APPLICATION_JSON_VALUE })
   public Workflow deactivateWorkflow(@RequestBody Workflow workflow) {
     log.debug("Deactivating Workflow: {}", workflow == null ? null : workflow.getId());
     return camundaApiService.undeployWorkflow(workflow);

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -54,100 +54,11 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Workflow'
-  /workflow-engine/workflows/deactivate/:
-    post:
-      tags:
-      - workflow-controller
-      operationId: deactivateWorkflow_1
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/Workflow'
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
-  /workflow-engine/workflows/activate/:
-    post:
-      tags:
-      - workflow-controller
-      operationId: activateWorkflow
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                workflow:
-                  $ref: '#/components/schemas/Workflow'
-                tenant:
-                  type: string
-        required: true
-      responses:
-        "400":
-          description: Bad Request
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "204":
-          description: No Content
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "404":
-          description: Not Found
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "200":
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/Workflow'
   /workflow-engine/workflows/activate:
     post:
       tags:
       - workflow-controller
-      operationId: activateWorkflow_1
+      operationId: activateWorkflow
       requestBody:
         content:
           application/json:


### PR DESCRIPTION
Resolves [MODCAMUNDA-3](https://github.com/folio-org/mod-camunda/compare/MODCAMUNDA-3).

These extra paths with a trailing forward-slash `/` (U+002F) should not longer be needed.

The `openapi.xml` file is rebuilt using `mvn clean verify -P openapi`.

There should no longer be any controller endpoints with explicit trailing slashes defined.