### PR TITLE
MODCAMUNDA-21: Upgrade spring-boot 3.3.7 and graalvm to 24.1.1.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk17:latest
+FROM folioci/alpine-jre-openjdk21:latest
 
 # Install latest patch versions of packages: https://pythonspeed.com/articles/security-updates-in-docker/
 USER root

--- a/pom.xml
+++ b/pom.xml
@@ -280,12 +280,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.graalvm.js</groupId>
-      <artifactId>js-scriptengine</artifactId>
-      <version>${graalvm.polyglot.version}</version>
-    </dependency>
-
-    <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId>
       <version>${graalvm.polyglot.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,14 @@
           <groupId>javax.mail</groupId>
           <artifactId>mailapi</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>org.graalvm.js</groupId>
+          <artifactId>js</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.graalvm.js</groupId>
+          <artifactId>js-scriptengine</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 
@@ -245,38 +253,41 @@
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
+      <artifactId>js-community</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
       <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.python</groupId>
-      <artifactId>python-language</artifactId>
+      <artifactId>python-community</artifactId>
       <version>${graalvm.polyglot.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.graalvm.python</groupId>
-      <artifactId>python-resources</artifactId>
-      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.ruby</groupId>
-      <artifactId>ruby-language</artifactId>
+      <artifactId>ruby-community</artifactId>
       <version>${graalvm.polyglot.version}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.graalvm.ruby</groupId>
-      <artifactId>ruby-resources</artifactId>
-      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
     </dependency>
 
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
       <version>9.4.9.0</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.shadowed</groupId>
+      <artifactId>json</artifactId>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
@@ -364,6 +375,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>-XX:+EnableDynamicAgentLoading</argLine><!-- Suppress "A java agent has been loaded dynamically" warning. -->
+        </configuration>
       </plugin>
 
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,10 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring-module-core.version>2.1.0-SNAPSHOT</spring-module-core.version>
     <workflow-components.version>1.2.0-SNAPSHOT</workflow-components.version>
-    <camunda.version>7.21.0-alpha2</camunda.version>
+    <camunda.version>7.21.0</camunda.version>
     <openapi.server.port>9000</openapi.server.port>
     <maven.javadoc.skip>true</maven.javadoc.skip>
+    <graalvm.polyglot.version>24.1.1</graalvm.polyglot.version>
   </properties>
 
   <packaging>jar</packaging>
@@ -186,9 +187,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.jcraft</groupId>
+      <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.1.55</version>
+      <version>0.1.72</version>
     </dependency>
 
     <dependency>
@@ -200,7 +201,7 @@
     <dependency>
       <groupId>org.python</groupId>
       <artifactId>jython-standalone</artifactId>
-      <version>2.7.3</version>
+      <version>2.7.4</version>
     </dependency>
 
     <dependency>
@@ -244,50 +245,99 @@
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
-      <artifactId>js</artifactId>
-      <version>23.0.4</version>
+      <artifactId>js-scriptengine</artifactId>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python-language</artifactId>
-      <version>23.1.3</version>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.python</groupId>
       <artifactId>python-resources</artifactId>
-      <version>23.1.3</version>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.ruby</groupId>
       <artifactId>ruby-language</artifactId>
-      <version>23.1.3</version>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.ruby</groupId>
       <artifactId>ruby-resources</artifactId>
-      <version>23.1.3</version>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
-      <version>9.4.7.0</version>
+      <version>9.4.9.0</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.js</groupId>
       <artifactId>js-scriptengine</artifactId>
-      <version>23.1.2</version>
+      <version>${graalvm.polyglot.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.graalvm.polyglot</groupId>
       <artifactId>polyglot</artifactId>
-      <version>23.1.3</version>
+      <version>${graalvm.polyglot.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>java</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>js</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>llvm</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>lsp</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>python</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>ruby</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
+    </dependency>
+
+    <dependency>
+      <groupId>org.graalvm.polyglot</groupId>
+      <artifactId>wasm</artifactId>
+      <version>${graalvm.polyglot.version}</version>
+      <type>pom</type>
     </dependency>
 
     <dependency>

--- a/src/main/resources/openapi.yaml
+++ b/src/main/resources/openapi.yaml
@@ -21,7 +21,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Workflow'
+              $ref: "#/components/schemas/Workflow"
         required: true
       responses:
         "400":
@@ -29,31 +29,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
   /workflow-engine/workflows/activate:
     post:
       tags:
@@ -66,7 +66,7 @@ paths:
               type: object
               properties:
                 workflow:
-                  $ref: '#/components/schemas/Workflow'
+                  $ref: "#/components/schemas/Workflow"
                 tenant:
                   type: string
         required: true
@@ -76,31 +76,31 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Workflow'
+                $ref: "#/components/schemas/Workflow"
   /_/tenant:
     post:
       tags:
@@ -121,7 +121,7 @@ paths:
                 tenant:
                   type: string
                 attributes:
-                  $ref: '#/components/schemas/TenantAttributes'
+                  $ref: "#/components/schemas/TenantAttributes"
         required: true
       responses:
         "400":
@@ -129,25 +129,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -175,25 +175,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
   /admin:
@@ -208,25 +208,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -236,21 +236,21 @@ paths:
                 additionalProperties:
                   type: object
                   additionalProperties:
-                    $ref: '#/components/schemas/Link'
+                    $ref: "#/components/schemas/Link"
             application/vnd.spring-boot.actuator.v2+json:
               schema:
                 type: object
                 additionalProperties:
                   type: object
                   additionalProperties:
-                    $ref: '#/components/schemas/Link'
+                    $ref: "#/components/schemas/Link"
             application/json:
               schema:
                 type: object
                 additionalProperties:
                   type: object
                   additionalProperties:
-                    $ref: '#/components/schemas/Link'
+                    $ref: "#/components/schemas/Link"
   /admin/info:
     get:
       tags:
@@ -263,25 +263,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -306,25 +306,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -349,25 +349,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -407,25 +407,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -459,25 +459,25 @@ paths:
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
-        "500":
-          description: Internal Server Error
-          content:
-            application/hal+json:
-              schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "204":
           description: No Content
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
+        "500":
+          description: Internal Server Error
+          content:
+            application/hal+json:
+              schema:
+                $ref: "#/components/schemas/ResponseErrors"
         "404":
           description: Not Found
           content:
             application/hal+json:
               schema:
-                $ref: '#/components/schemas/ResponseErrors'
+                $ref: "#/components/schemas/ResponseErrors"
         "200":
           description: OK
           content:
@@ -500,7 +500,7 @@ components:
         parameters:
           type: array
           items:
-            $ref: '#/components/schemas/Parameter'
+            $ref: "#/components/schemas/Parameter"
     Parameter:
       type: object
       properties:
@@ -514,563 +514,12 @@ components:
         errors:
           type: array
           items:
-            $ref: '#/components/schemas/Error'
+            $ref: "#/components/schemas/Error"
         total_records:
           type: integer
           format: int32
-    CompressFileTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          source:
-            type: string
-          destination:
-            type: string
-          format:
-            type: string
-            enum:
-            - BZIP2
-            - GZIP
-            - ZIP
-          container:
-            type: string
-            enum:
-            - NONE
-            - TAR
-    Condition:
-      required:
-      - answer
-      - expression
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          answer:
-            maxLength: 64
-            minLength: 2
-            type: string
-          expression:
-            maxLength: 128
-            minLength: 4
-            type: string
-    ConnectTo:
-      required:
-      - name
-      - nodeId
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          nodeId:
-            type: string
-    DatabaseConnectionTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-          password:
-            type: string
-          url:
-            type: string
-          username:
-            type: string
-    DatabaseDisconnectTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-    DatabaseQueryTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          designation:
-            type: string
-          outputPath:
-            type: string
-          query:
-            type: string
-          resultType:
-            type: string
-            enum:
-            - CSV
-            - TSV
-            - JSON
-          includeHeader:
-            type: boolean
-    DirectoryTask:
-      required:
-      - action
-      - name
-      - path
-      - workflow
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          path:
-            type: string
-          workflow:
-            type: string
-          action:
-            type: string
-            enum:
-            - READ_NEXT
-            - DELETE_NEXT
-            - LIST
-            - WRITE
-    EmailTask:
-      required:
-      - mailFrom
-      - mailSubject
-      - mailText
-      - mailTo
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          attachmentPath:
-            type: string
-          includeAttachment:
-            type: string
-          mailBcc:
-            type: string
-          mailCc:
-            type: string
-          mailFrom:
-            maxLength: 256
-            minLength: 3
-            type: string
-          mailText:
-            maxLength: 2147483647
-            minLength: 2
-            type: string
-          mailTo:
-            maxLength: 256
-            minLength: 3
-            type: string
-          mailMarkup:
-            type: string
-          mailSubject:
-            maxLength: 256
-            minLength: 2
-            type: string
-    EmbeddedInput:
-      required:
-      - inputType
-      type: object
-      properties:
-        attributes:
-          type: array
-          items:
-            type: string
-            enum:
-            - MAX
-            - MAXLENGTH
-            - MIN
-            - PATTERN
-            - SIZE
-            - STEP
-        defaultValue:
-          type: string
-        fieldId:
-          type: string
-        fieldLabel:
-          type: string
-        inputType:
-          type: string
-          enum:
-          - BUTTON
-          - CHECKBOX
-          - COLOR
-          - DATE
-          - DATETIME
-          - EMAIL
-          - FILE
-          - HIDDEN
-          - IMAGE
-          - MONTH
-          - NUMBER
-          - PASSWORD
-          - RADIO
-          - RANGE
-          - SEARCH
-          - SELECT
-          - SUBMIT
-          - TELEPHONE
-          - TEXT
-          - TIME
-          - URL
-          - WEEK
-        options:
-          type: array
-          items:
-            type: string
-        required:
-          type: boolean
-    EmbeddedLoopReference:
-      required:
-      - parallel
-      type: object
-      properties:
-        cardinalityExpression:
-          type: string
-        completeConditionExpression:
-          type: string
-        dataInputRefExpression:
-          type: string
-        inputDataName:
-          type: string
-        parallel:
-          type: boolean
-    EmbeddedProcessor:
-      required:
-      - code
-      - functionName
-      - scriptType
-      type: object
-      properties:
-        buffer:
-          type: integer
-          format: int32
-        code:
-          type: string
-        delay:
-          type: integer
-          format: int32
-        functionName:
-          maxLength: 128
-          minLength: 4
-          type: string
-        scriptType:
-          type: string
-          enum:
-          - GROOVY
-          - JAVA
-          - JS
-          - PYTHON
-          - RUBY
-    EmbeddedRequest:
-      required:
-      - accept
-      - contentType
-      - method
-      - url
-      type: object
-      properties:
-        accept:
-          type: string
-        bodyTemplate:
-          type: string
-        contentType:
-          type: string
-        iterable:
-          type: boolean
-        iterableKey:
-          type: string
-        method:
-          type: string
-          enum:
-          - GET
-          - HEAD
-          - POST
-          - PUT
-          - PATCH
-          - DELETE
-          - OPTIONS
-          - TRACE
-        responseKey:
-          type: string
-        url:
-          type: string
-    EmbeddedVariable:
-      required:
-      - key
-      type: object
-      properties:
-        key:
-          maxLength: 64
-          minLength: 4
-          type: string
-        type:
-          type: string
-          enum:
-          - PROCESS
-          - LOCAL
-        spin:
-          type: boolean
-        asJson:
-          type: boolean
-        asTransient:
-          type: boolean
-    EndEvent:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-    EventSubprocess:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-    ExclusiveGateway:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    FileTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          line:
-            type: string
-          op:
-            type: string
-            enum:
-            - LIST
-            - READ
-            - WRITE
-            - COPY
-            - MOVE
-            - DELETE
-            - LINE_COUNT
-            - READ_LINE
-            - PUSH
-            - POP
-          path:
-            type: string
-          target:
-            type: string
-    FtpTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          destinationPath:
-            type: string
-          host:
-            type: string
-          op:
-            type: string
-            enum:
-            - GET
-            - PUT
-          originPath:
-            type: string
-          password:
-            type: string
-          port:
-            type: integer
-            format: int32
-          scheme:
-            type: string
-          username:
-            type: string
-          basePath:
-            type: string
-    InclusiveGateway:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    InputTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          inputs:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedInput'
     JsonNode:
       type: object
-    MoveToLastGateway:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    MoveToNode:
-      required:
-      - gatewayId
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          gatewayId:
-            type: string
     Node:
       required:
       - name
@@ -1091,120 +540,6 @@ components:
           readOnly: true
         identifier:
           type: string
-      discriminator:
-        propertyName: deserializeAs
-    ParallelGateway:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          direction:
-            type: string
-            enum:
-            - UNSPECIFIED
-            - CONVERGING
-            - DIVERGING
-            - MIXED
-    ProcessorTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          processor:
-            $ref: '#/components/schemas/EmbeddedProcessor'
-    ReceiveTask:
-      required:
-      - message
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          message:
-            maxLength: 256
-            minLength: 4
-            type: string
-    RequestTask:
-      required:
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          headerOutputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          request:
-            $ref: '#/components/schemas/EmbeddedRequest'
-    ScriptTask:
-      required:
-      - code
-      - name
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          inputVariables:
-            uniqueItems: true
-            type: array
-            items:
-              $ref: '#/components/schemas/EmbeddedVariable'
-          outputVariable:
-            $ref: '#/components/schemas/EmbeddedVariable'
-          code:
-            type: string
-          resultVariable:
-            type: string
-          scriptFormat:
-            type: string
     Setup:
       type: object
       properties:
@@ -1212,52 +547,6 @@ components:
           type: boolean
         asyncBefore:
           type: boolean
-    StartEvent:
-      required:
-      - name
-      - type
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncBefore:
-            type: boolean
-          expression:
-            maxLength: 256
-            minLength: 4
-            type: string
-          interrupting:
-            type: boolean
-          type:
-            type: string
-            enum:
-            - MESSAGE_CORRELATION
-            - SCHEDULED
-            - SIGNAL
-            - NONE
-    Subprocess:
-      required:
-      - name
-      - type
-      type: object
-      allOf:
-      - $ref: '#/components/schemas/Node'
-      - type: object
-        properties:
-          asyncAfter:
-            type: boolean
-          asyncBefore:
-            type: boolean
-          loopRef:
-            $ref: '#/components/schemas/EmbeddedLoopReference'
-          type:
-            type: string
-            enum:
-            - EMBEDDED
-            - TRANSACTION
-          multiInstance:
-            type: boolean
     Workflow:
       required:
       - name
@@ -1281,7 +570,7 @@ components:
         initialContext:
           type: object
           additionalProperties:
-            $ref: '#/components/schemas/JsonNode'
+            $ref: "#/components/schemas/JsonNode"
         name:
           maxLength: 64
           minLength: 4
@@ -1289,33 +578,9 @@ components:
         nodes:
           type: array
           items:
-            oneOf:
-            - $ref: '#/components/schemas/CompressFileTask'
-            - $ref: '#/components/schemas/Condition'
-            - $ref: '#/components/schemas/ConnectTo'
-            - $ref: '#/components/schemas/DatabaseConnectionTask'
-            - $ref: '#/components/schemas/DatabaseDisconnectTask'
-            - $ref: '#/components/schemas/DatabaseQueryTask'
-            - $ref: '#/components/schemas/DirectoryTask'
-            - $ref: '#/components/schemas/EmailTask'
-            - $ref: '#/components/schemas/EndEvent'
-            - $ref: '#/components/schemas/EventSubprocess'
-            - $ref: '#/components/schemas/ExclusiveGateway'
-            - $ref: '#/components/schemas/FileTask'
-            - $ref: '#/components/schemas/FtpTask'
-            - $ref: '#/components/schemas/InclusiveGateway'
-            - $ref: '#/components/schemas/InputTask'
-            - $ref: '#/components/schemas/MoveToLastGateway'
-            - $ref: '#/components/schemas/MoveToNode'
-            - $ref: '#/components/schemas/ParallelGateway'
-            - $ref: '#/components/schemas/ProcessorTask'
-            - $ref: '#/components/schemas/ReceiveTask'
-            - $ref: '#/components/schemas/RequestTask'
-            - $ref: '#/components/schemas/ScriptTask'
-            - $ref: '#/components/schemas/StartEvent'
-            - $ref: '#/components/schemas/Subprocess'
+            $ref: "#/components/schemas/Node"
         setup:
-          $ref: '#/components/schemas/Setup'
+          $ref: "#/components/schemas/Setup"
         versionTag:
           maxLength: 64
           minLength: 1

--- a/src/test/java/org/folio/rest/camunda/delegate/FileDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/FileDelegateTest.java
@@ -10,6 +10,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -19,10 +22,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.StringUtils;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.delegate.DelegateExecution;
@@ -82,6 +81,7 @@ class FileDelegateTest {
   @InjectMocks
   FileDelegate delegate;
 
+  @SuppressWarnings("serial")
   private final Map<String, Object> mockData = new HashMap<>() {{
     put("data", new ArrayList<>() {{
       add("Hello, World!");

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -11,7 +11,7 @@ logging:
       folio: WARN
       hibernate: WARN
       springframework: WARN
-      springframework.test: INFO
+      springframework.test: WARN
 
       # Uncomment to enable MockMvc unit test logging.
       #springframework.test.web.servlet.result: DEBUG


### PR DESCRIPTION
Resolves [MODCAMUNDA-21](https://folio-org.atlassian.net/browse/MODCAMUNDA-21)

Switch to JDK21 which has better spring-boot 3.3.x support as well as better GraalVM support.

The `com.jcraft` has migrated to `com.github.mwiede`, so update that and the version.

Update the graalvm related dependencies.
Add the polyglot dependencies.

~The `org.jacoco` `jacoco-maven-plugin` must be upgraded or it will fail with the new spring-boot 3.3.x changes.~

Fix some warnings and change the default `springframework.test` setting.

Remove duplicate dependency in the pom file.

The `-community` edition of the packages should be brought in due to licensing concerns.
Remove the direct dependencies that are already brought in already via the `-community` editions.

Suppress the `graalvm.js` that is brought in from `data-import-processing-core` due to version dependency conflicts.
The version from `graalvm.js` brought in from `data-import-processing-core` is also not the `-community` edition.

Suppress the warning bout dynamically loading bytebuddy as per:
```
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
