### PR TITLE
MODCAMUNDA-24: CWE-611: Upgrade hadoop to 3.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -191,8 +191,21 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-vfs2</artifactId>
-      <version>2.8.0</version>
+      <version>2.9.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
+   <!-- Security: Override version coming from commons-vfs2, remove this and exclusion once commons-vfs2 is updated.-->
+   <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs-client</artifactId>
+      <version>3.4.1</version>
+   </dependency>
 
     <dependency>
       <groupId>com.github.mwiede</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -204,18 +204,6 @@
       </exclusions>
     </dependency>
 
-   <!-- Security: Override version coming from commons-vfs2, remove this and exclusion once commons-vfs2 is updated.-->
-   <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs</artifactId>
-      <version>3.4.1</version>
-   </dependency>
-   <dependency>
-      <groupId>org.apache.hadoop</groupId>
-      <artifactId>hadoop-hdfs-client</artifactId>
-      <version>3.4.1</version>
-   </dependency>
-
     <dependency>
       <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -195,12 +195,21 @@
       <exclusions>
         <exclusion>
           <groupId>org.apache.hadoop</groupId>
+          <artifactId>hadoop-hdfs</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-hdfs-client</artifactId>
         </exclusion>
       </exclusions>
     </dependency>
 
    <!-- Security: Override version coming from commons-vfs2, remove this and exclusion once commons-vfs2 is updated.-->
+   <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <version>3.4.1</version>
+   </dependency>
    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-hdfs-client</artifactId>


### PR DESCRIPTION
Resolves [MODCAMUNDA-24](https://folio-org.atlassian.net/browse/MODCAMUNDA-24)

see: https://cwe.mitre.org/data/definitions/611.html

The `commons-vfs2` has not seen updates in a long time.
This gives reason to add an exclusion and manually add the dependency.