### PR TITLE
MODCAMUNDA-29: Upgrade from ojdbc10 to ojdbc11.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -240,8 +240,7 @@
 
     <dependency>
       <groupId>com.oracle.database.jdbc</groupId>
-      <artifactId>ojdbc10</artifactId>
-      <version>19.14.0.0</version>
+      <artifactId>ojdbc11</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Resolves [MODCAMUNDA-29](https://folio-org.atlassian.net/browse/MODCAMUNDA-29).

The original request is to upgrade specifically to `21.17.0.0`.

I have discovered that this `ojdbc11` is version managed by `spring-boot`. Let `spring-boot` manage this version.