### PR TITLE
MODCAMUNDA-26: Make compatible with spring-boot 3.4 upgrades.

### DIFF
--- a/src/test/java/org/folio/rest/camunda/controller/WorkflowControllerTest.java
+++ b/src/test/java/org/folio/rest/camunda/controller/WorkflowControllerTest.java
@@ -52,9 +52,11 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -79,10 +81,10 @@ class WorkflowControllerTest {
   @Autowired
   private WorkflowController workflowController;
 
-  @MockBean
+  @MockitoBean
   private CamundaApiService camundaApiService;
 
-  @MockBean
+  @MockitoBean
   private TenantProperties tenantProperties;
 
   @BeforeEach

--- a/src/test/java/org/folio/rest/camunda/kafka/EventConsumerTest.java
+++ b/src/test/java/org/folio/rest/camunda/kafka/EventConsumerTest.java
@@ -5,12 +5,11 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 
-import java.util.HashMap;
-import java.util.stream.Stream;
-
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashMap;
+import java.util.stream.Stream;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.runtime.MessageCorrelationBuilder;
 import org.camunda.bpm.engine.runtime.ProcessInstance;
@@ -24,18 +23,20 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
 @ExtendWith(MockitoExtension.class)
 class EventConsumerTest {
 
-  @SpyBean
+  @MockitoSpyBean
   private ObjectMapper objectMapper;
 
-  @MockBean
+  @MockitoBean
   private RuntimeService runtimeService;
 
   @Mock
@@ -46,6 +47,16 @@ class EventConsumerTest {
 
   @InjectMocks
   private EventConsumer eventConsumer;
+
+  // Provide a bean for `@MockitoSpyBean` above to work without requiring a full spring boot runner.
+  @Configuration
+  static class Config {
+
+    @Bean
+    ObjectMapper objectMapper() {
+      return new ObjectMapper();
+    }
+  }
 
   @ParameterizedTest
   @MethodSource("eventStream")


### PR DESCRIPTION
Resolves [MODCAMUNDA-26](https://folio-org.atlassian.net/browse/MODCAMUNDA-26).

Replace `@MockBean` and `@SpyBean`.
  - `@MockitoBean` and `MockitoSpyBean` are the replacemenets to the deprecated or removed `@MockBean` and `@SpyBean`.

Address failing bean problems.
  - The `ObjectMapper` bean is provided because the `@MockitoSpyBean` no longer instantiates when there is no bean found in the way that no available or deprecated `@SpyBean` does.
  - see: https://github.com/spring-projects/spring-framework/issues/33935

This requires the changes from [Spring Module Core PR 74](https://github.com/folio-org/spring-module-core/pull/74) for [SPRNGCORE-6](https://folio-org.atlassian.net/browse/SPRNGCORE-6).