### PR TITLE
MODCAMUNDA-34: data-import-processing-core 4.3.2 → 4.4.0 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>4.3.2</version>
+      <version>4.4.0</version>
       <exclusions>
         <exclusion>
           <groupId>org.folio</groupId>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODCAMUNDA-34

Upgrade data-import-processing-core from 4.3.2 to 4.4.0.

This will indirectly upgrade these transitive dependencies:

* snappy-java from 1.1.8.4 to 1.1.10.5 fixing
  * CVE-2023-43642 – https://github.com/advisories/GHSA-55g7-9cwv-5qfv – DoS due to missing chunk length check
  * CVE-2023-34455 – https://github.com/advisories/GHSA-qcwq-55hx-v3vh – DoS due to missing chunk length check
  * CVE-2023-34453 – https://github.com/advisories/GHSA-pqr6-cmr2-h8hf – Integer overflow DoS
  * CVE-2023-34454 – https://github.com/advisories/GHSA-fjpj-2g6w-x25r – Compress overflow DoS
* kafka-clients from 3.3.2 to 3.8.1 fixing
  * CVE-2024-56128 – https://github.com/advisories/GHSA-p7c9-8xx8-h74f – Incorrect SCRAM authentication
  * CVE-2023-25194 – https://github.com/advisories/GHSA-26f8-x7cc-wqpc – Deserialization of Untrusted Data
  * CVE-2024-31141 – https://github.com/advisories/GHSA-2x2g-32r7-p4x8 – File system privilege escalation