### PR TITLE
Bump versions of numerous explicit dependencies.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
     <camunda.version>7.21.0</camunda.version>
     <openapi.server.port>9000</openapi.server.port>
     <maven.javadoc.skip>true</maven.javadoc.skip>
-    <graalvm.polyglot.version>24.1.2</graalvm.polyglot.version>
+    <graalvm.polyglot.version>24.2.2</graalvm.polyglot.version>
   </properties>
 
   <packaging>jar</packaging>
@@ -85,7 +85,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>data-import-processing-core</artifactId>
-      <version>4.4.0</version>
+      <version>4.4.3</version>
       <exclusions>
         <exclusion>
           <groupId>org.folio</groupId>
@@ -174,13 +174,13 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-collections4</artifactId>
-      <version>4.4</version>
+      <version>4.5.0</version>
     </dependency>
 
     <dependency>
        <groupId>org.apache.commons</groupId>
        <artifactId>commons-compress</artifactId>
-       <version>1.26.1</version>
+       <version>1.28.0</version>
     </dependency>
 
     <dependency>
@@ -207,7 +207,7 @@
     <dependency>
       <groupId>com.github.mwiede</groupId>
       <artifactId>jsch</artifactId>
-      <version>0.2.21</version>
+      <version>0.2.26</version>
     </dependency>
 
     <dependency>
@@ -251,13 +251,13 @@
     <dependency>
       <groupId>com.googlecode.libphonenumber</groupId>
       <artifactId>libphonenumber</artifactId>
-      <version>8.13.54</version>
+      <version>8.13.55</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-text</artifactId>
-      <version>1.13.0</version>
+      <version>1.14.0</version>
     </dependency>
 
     <dependency>
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby</artifactId>
-      <version>9.4.12.1</version>
+      <version>9.4.13.0</version>
     </dependency>
 
     <dependency>
@@ -392,7 +392,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.13</version>
         <executions>
           <execution>
             <goals>


### PR DESCRIPTION
- [MODCAMUNDA-37](https://folio-org.atlassian.net/browse/MODCAMUNDA-37)
- [MODCAMUNDA-38](https://folio-org.atlassian.net/browse/MODCAMUNDA-38)
- [MODCAMUNDA-39](https://folio-org.atlassian.net/browse/MODCAMUNDA-39)
- [MODCAMUNDA-40](https://folio-org.atlassian.net/browse/MODCAMUNDA-40)
- [MODCAMUNDA-41](https://folio-org.atlassian.net/browse/MODCAMUNDA-41)
- [MODCAMUNDA-42](https://folio-org.atlassian.net/browse/MODCAMUNDA-42)
- [MODCAMUNDA-43](https://folio-org.atlassian.net/browse/MODCAMUNDA-43)
- [MODCAMUNDA-44](https://folio-org.atlassian.net/browse/MODCAMUNDA-44)


Note that `7.23.0` of `camunda` causes compilation failure and is not upgraded at this time. Even `7.22.0` has problems.
This is the test failure from attempting to upgrade to `7.22.0` of camunda:
```
[ERROR]   WorkflowControllerAdviceTest.exceptionsThrownForActivateWorkflowTest(Exception, String, int)[1] » IllegalState Failed to load ApplicationContext for [WebMergedContextConfiguration@29e3c7fe testClass = org.folio.rest.camunda.controller.advice.WorkflowControllerAdviceTest, locations = [], classes = [org.folio.rest.camunda.SpringOkapiModule], contextInitializerClasses = [], activeProfiles = [], propertySourceDescriptors = [], propertySourceProperties = ["org.springframework.boot.test.context.SpringBootTestContextBootstrapper=true"], contextCustomizers = [[ImportsContextCustomizer@1205d231 key = [org.springframework.boot.test.autoconfigure.web.servlet.MockMvcWebDriverAutoConfiguration, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcAutoConfiguration, org.springframework.boot.autoconfigure.security.oauth2.client.servlet.OAuth2ClientAutoConfiguration, org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration, org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration, org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration, org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcSecurityConfiguration, org.springframework.boot.test.autoconfigure.web.servlet.MockMvcWebClientAutoConfiguration, org.springframework.boot.test.autoconfigure.web.reactive.WebTestClientAutoConfiguration]], org.springframework.boot.test.context.filter.ExcludeFilterContextCustomizer@3d1848cc, org.springframework.boot.test.json.DuplicateJsonObjectContextCustomizerFactory$DuplicateJsonObjectContextCustomizer@1b7c473a, org.springframework.boot.test.mock.mockito.MockitoContextCustomizer@0, org.springframework.boot.test.web.client.TestRestTemplateContextCustomizer@62ef27a8, org.springframework.boot.test.web.reactive.server.WebTestClientContextCustomizer@1afdd473, org.springframework.boot.test.web.reactor.netty.DisableReactorResourceFactoryGlobalResourcesContextCustomizerFactory$DisableReactorResourceFactoryGlobalResourcesContextCustomizerCustomizer@403f0a22, org.springframework.boot.test.autoconfigure.OnFailureConditionReportContextCustomizerFactory$OnFailureConditionReportContextCustomizer@6995bf68, org.springframework.boot.test.autoconfigure.actuate.observability.ObservabilityContextCustomizerFactory$DisableObservabilityContextCustomizer@1f, org.springframework.boot.test.autoconfigure.properties.PropertyMappingContextCustomizer@4b3fa0b3, org.springframework.boot.test.autoconfigure.web.servlet.WebDriverContextCustomizer@66ac5762, org.springframework.test.context.support.DynamicPropertiesContextCustomizer@0, org.springframework.boot.test.context.SpringBootTestAnnotation@ffb26eb5], resourceBasePath = "src/main/webapp", contextLoader = org.springframework.boot.test.context.SpringBootContextLoader, parent = null]
```