### PR TITLE
MODCAMUNDA-56: Explicitly set the schema name and enable it by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ The following is a summary of many of them.
 | CAMUNDA_BPM_METRICS               |           false             | Enable or disable Camunda metrics by default.
 | DB_CHARSET                        |           UTF-8             | Database charset.
 | DB_DATABASE                       |       okapi_modules         | Postgres database name.
+| DB_SCHEMA                         |      diku_mod_camunda       | Postgres database schema name.
 | DB_HOST                           |         postgres            | Postgres host name.
 | DB_MAXPOOLSIZE                    |             5               | Database max pool size.
 | DB_PASSWORD                       |         folio_admin         | Postgres user password (be sure to change this).

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -395,6 +395,7 @@
       { "name": "DB_USERNAME", "value": "folio_admin", "description": "Postgres user name." },
       { "name": "DB_PASSWORD", "value": "folio_admin", "description": "Postgres user name password." },
       { "name": "DB_DATABASE", "value": "okapi_modules", "description": "Postgres database name." },
+      { "name": "DB_SCHEMA", "value": "diku_mod_camunda", "description": "Postgres database schema name." },
       { "name": "DB_QUERYTIMEOUT", "value": "60000", "description": "Database query timeout." },
       { "name": "DB_CHARSET", "value": "UTF-8", "description": "Database charset." },
       { "name": "DB_MAXPOOLSIZE", "value": "16", "description": "Database max pool size." },

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -56,7 +56,7 @@ spring:
     #url: jdbc:h2:./target/mod-camunda;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
     #driverClassName: org.h2.Driver
     driverClassName: org.postgresql.Driver
-    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_DATABASE:mod_camunda}
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_DATABASE:mod_camunda}?currentSchema=${DB_SCHEMA:diku_mod_camunda},public
 
     username: ${DB_USERNAME:folio_admin}
     password: ${DB_PASSWORD:folio_admin}
@@ -75,6 +75,10 @@ spring:
   jpa:
     #database-platform: org.hibernate.dialect.H2Dialect
     database-platform: org.hibernate.dialect.PostgreSQLDialect
+
+    properties.hibernate:
+      jdbc.lob.non_contextual_creation: true
+      default_schema: ${DB_SCHEMA:diku_mod_camunda}
 
     properties.hibernate.jdbc.lob.non_contextual_creation: true
     generate-ddl: false
@@ -114,7 +118,10 @@ camunda:
       application-path: ui
     auto-deployment-enabled: false
     database:
+      schema-name: ${DB_SCHEMA:diku_mod_camunda}
+      table-prefix: ${DB_SCHEMA:diku_mod_camunda}.
       schema-update: true
+      type: postgres
     filter:
       create: All Tasks
     admin-user:


### PR DESCRIPTION
Resolves [MODCAMUNDA-56](https://folio-org.atlassian.net/browse/MODCAMUNDA-56) .

Expose the schema name via `DB_SCHEMA`.
The name includes the tenant name followed by the module name.

The Camunda dependencies require their own explicit settings. The `table-prefix` is required to ensure that the schema name is explicitly added to avoid problems where Camunda itself does not include the correct default search path.