### PR TITLE
MODCAMUNDA-59: Utilize `folio.sql.schema` from spring-module-core tenant module.

### DIFF
--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -175,6 +175,9 @@ application:
         topic-pattern: ${ENV:folio}.(.*\.)?camunda.events
         group-id: ${ENV:folio}-mod-camunda-events-group
 
+folio:
+  sql.schema: ${DB_SCHEMA:diku_mod_camunda}
+
 tenant:
   header-name: X-Okapi-Tenant
   force-tenant: false


### PR DESCRIPTION
Resolves [MODCAMUNDA-59](https://folio-org.atlassian.net/browse/MODCAMUNDA-59) .

Provide explicit default schema name.