### PR TITLE
MODCAMUNDA-66: Utilize sendEmptyBody from RequestTask and address issues.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/controller/advice/GlobalAdvice.java
+++ b/src/main/java/org/folio/rest/camunda/controller/advice/GlobalAdvice.java
@@ -5,6 +5,7 @@ import org.folio.rest.camunda.exception.BpmnModelFailure;
 import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.exception.DelegateSpinFailure;
 import org.folio.rest.camunda.exception.EmailDelegateAddressFailure;
+import org.folio.rest.camunda.exception.RequestMissingWorkflowException;
 import org.folio.rest.camunda.exception.ScriptEngineLoadFailed;
 import org.folio.rest.camunda.exception.ScriptEngineUnsupported;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
@@ -68,6 +69,12 @@ public class GlobalAdvice extends AbstractAdvice {
   @ExceptionHandler(EmailDelegateAddressFailure.class)
   public ResponseEntity<String> handleEmailDelegateAddressFailure(EmailDelegateAddressFailure exception) {
     return buildError(exception, HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+  }
+
+  @ResponseStatus(HttpStatus.BAD_REQUEST)
+  @ExceptionHandler(RequestMissingWorkflowException.class)
+  public ResponseEntity<String> handleRequestMissingWorkflowException(RequestMissingWorkflowException exception) {
+    return buildError(exception, HttpStatus.BAD_REQUEST, MediaType.APPLICATION_JSON);
   }
 
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/org/folio/rest/camunda/controller/advice/GlobalAdvice.java
+++ b/src/main/java/org/folio/rest/camunda/controller/advice/GlobalAdvice.java
@@ -2,6 +2,7 @@ package org.folio.rest.camunda.controller.advice;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import org.folio.rest.camunda.exception.BpmnModelFailure;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.exception.DelegateSpinFailure;
 import org.folio.rest.camunda.exception.EmailDelegateAddressFailure;
 import org.folio.rest.camunda.exception.ScriptEngineLoadFailed;
@@ -48,6 +49,12 @@ public class GlobalAdvice extends AbstractAdvice {
   @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
   @ExceptionHandler(BpmnModelFailure.class)
   public ResponseEntity<String> handleBpmnModelFailure(BpmnModelFailure exception) {
+    return buildError(exception, HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
+  }
+
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  @ExceptionHandler(DelegateExecutionFailure.class)
+  public ResponseEntity<String> handleDelegateExecutionFailure(DelegateExecutionFailure exception) {
     return buildError(exception, HttpStatus.INTERNAL_SERVER_ERROR, MediaType.APPLICATION_JSON);
   }
 

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
@@ -1,7 +1,9 @@
 package org.folio.rest.camunda.delegate;
 
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.JavaDelegate;
+import org.operaton.bpm.model.bpmn.instance.FlowElement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,20 +31,24 @@ public abstract class AbstractDelegate implements JavaDelegate {
    * Perform the execution.
    *
    * @param execution The execution data.
+   *
+   * @throws Exception on error.
    */
   @Override
   public void execute(DelegateExecution execution) throws Exception {
 
-    final String name = getDelegateName(execution);
+    final FlowElement flow = execution.getBpmnModelElementInstance();
+    final String name = flow.getName();
+    final String id = flow.getId();
     final long startTime = determineStartTime(execution, name);
 
     try {
-      performExecute(execution, name);
+      performExecute(execution, name, id);
       determineEndTime(execution, startTime, name, false);
     } catch (Exception e) {
       determineEndTime(execution, startTime, name, true);
 
-      throw e;
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
     }
   }
 
@@ -53,10 +59,9 @@ public abstract class AbstractDelegate implements JavaDelegate {
    *
    * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On error.
+   * @param id        The delegate ID.
    */
-  protected abstract void performExecute(DelegateExecution execution, String name) throws Exception;
+  protected abstract void performExecute(DelegateExecution execution, String name, String id);
 
   /**
    * Get the delegate class name.
@@ -67,17 +72,6 @@ public abstract class AbstractDelegate implements JavaDelegate {
     String simpleName = getClass().getSimpleName();
 
     return simpleName.substring(0, 1).toLowerCase() + simpleName.substring(1);
-  }
-
-  /**
-   * Get the delegate name.
-   *
-   * @param execution The delegate execution data.
-   *
-   * @return The delegate name.
-   */
-  protected String getDelegateName(DelegateExecution execution) {
-    return execution.getBpmnModelElementInstance().getName();
   }
 
   /**

--- a/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/AbstractDelegate.java
@@ -17,10 +17,46 @@ public abstract class AbstractDelegate implements JavaDelegate {
   @Autowired
   protected JsonMapper mapper;
 
+  /**
+   * Initializer.
+   */
   AbstractDelegate() {
     // The logger is non-static to ensure that the implementing class name is used for the logger.
     log = LoggerFactory.getLogger(this.getClass());
   }
+
+  /**
+   * Perform the execution.
+   *
+   * @param execution The execution data.
+   */
+  @Override
+  public void execute(DelegateExecution execution) throws Exception {
+
+    final String name = getDelegateName(execution);
+    final long startTime = determineStartTime(execution, name);
+
+    try {
+      performExecute(execution, name);
+      determineEndTime(execution, startTime, name, false);
+    } catch (Exception e) {
+      determineEndTime(execution, startTime, name, true);
+
+      throw e;
+    }
+  }
+
+  /**
+   * Perform the execution operation with class specific details.
+   *
+   * This is intended to be called by the execute() method and should not need to be directly called.
+   *
+   * @param execution The execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On error.
+   */
+  protected abstract void performExecute(DelegateExecution execution, String name) throws Exception;
 
   /**
    * Get the delegate class name.
@@ -75,12 +111,18 @@ public abstract class AbstractDelegate implements JavaDelegate {
    * Determine the start time of the query and print log.
    *
    * @param execution The delegate execution data.
-   * @param args additional string arguments to pass.
+   * @param name      The delegate name.
+   * @param args      Additional string arguments to pass to the logger.
    *
    * @return The start time.
    */
-  protected long determineStartTime(DelegateExecution execution, Object ...args) {
-    getLogger().info("{} {} started", getDelegateName(execution), args);
+  protected long determineStartTime(DelegateExecution execution, String name, Object ...args) {
+
+    if (args == null) {
+      getLogger().info("{} started", name);
+    } else {
+      getLogger().info("{} {} started", name, args);
+    }
 
     return System.nanoTime();
   }
@@ -89,11 +131,13 @@ public abstract class AbstractDelegate implements JavaDelegate {
    * Given the start time, determine the total time spent.
    *
    * @param execution The delegate execution data.
-   *
    * @param startTime The time the process started.
+   * @param name      The delegate name.
+   * @param failed    If TRUE, then this is failed, otherwise this is success.
    */
-  protected void determineEndTime(DelegateExecution execution, long startTime) {
-    getLogger().info("{} finished in {} milliseconds", getDelegateName(execution), (System.nanoTime() - startTime) / (double) 1000000);
+  protected void determineEndTime(DelegateExecution execution, long startTime, String name, boolean failed) {
+
+    getLogger().info("{} {} in {} milliseconds", name, failed ? "failed" : "finished", (System.nanoTime() - startTime) / (double) 1000000);
   }
 
 }

--- a/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
@@ -30,6 +30,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.workflow.enums.CompressFileContainer;
 import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.model.CompressFileTask;
@@ -63,15 +64,14 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
   private Expression container;
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     String sourcePathTemplate = this.source.getValue(execution).toString();
     String destinationPathTemplate = this.destination.getValue(execution).toString();
@@ -84,8 +84,15 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
     cfg.setTemplateLoader(pathLoader);
 
     Map<String, Object> inputs = getInputs(execution);
-    String sourcePath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("sourcePath"), inputs);
-    String destinationPath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("destinationPath"), inputs);
+    String sourcePath;
+    String destinationPath;
+
+    try {
+      sourcePath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("sourcePath"), inputs);
+      destinationPath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("destinationPath"), inputs);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
 
     CompressFileFormat compressFormat = CompressFileFormat.valueOf(this.format.getValue(execution).toString());
     CompressFileContainer useContainer = CompressFileContainer.valueOf(this.container.getValue(execution).toString());
@@ -138,6 +145,8 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
       try (ZipOutputStream zipOut = createZipOutputStream(createFileOutputStream(destinationFile))) {
         zipOut.putNextEntry(new ZipEntry(sourceFile.getName()));
         filesCopy(sourceFile.toPath(), zipOut);
+      } catch (Exception e) {
+        throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
       }
     } else {
       getLogger().info("Format type: {}", formatType);
@@ -153,26 +162,24 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
             CompressorOutputStream<?> compress = createCompressorOutputStream(formatType, output);
           ) {
             iOUtilsCopyAndClose(input, compress);
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
           }
         } else if (useContainer == CompressFileContainer.TAR) {
-          FileOutputStream outputFile = createFileOutputStream(destinationFile);
-          BufferedOutputStream output = createBufferedOutputStream(outputFile);
+          try (
+            final FileOutputStream outputFile = createFileOutputStream(destinationFile);
+            final BufferedOutputStream output = createBufferedOutputStream(outputFile);
+            final CompressorOutputStream<?> compress = createCompressorOutputStream(formatType, output);
+            final TarArchiveOutputStream tar = createTarArchiveOutputStream(compress, BLOCK_SIZE, ENCODING);
+          ) {
+            tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
+            tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
 
-          CompressorOutputStream<?> compress = createCompressorOutputStream(formatType, output);
-
-          TarArchiveOutputStream tar = createTarArchiveOutputStream(compress, BLOCK_SIZE, ENCODING);
-
-          tar.setBigNumberMode(TarArchiveOutputStream.BIGNUMBER_POSIX);
-          tar.setLongFileMode(TarArchiveOutputStream.LONGFILE_POSIX);
-
-          try {
             addPaths(sourcePath, "", tar);
 
             tar.finish();
-          } finally {
-            tar.close();
-            compress.close();
-            outputFile.close();
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
           }
         }
 

--- a/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
@@ -62,9 +62,16 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
 
   private Expression container;
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     String sourcePathTemplate = this.source.getValue(execution).toString();
     String destinationPathTemplate = this.destination.getValue(execution).toString();
@@ -172,8 +179,6 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
         getLogger().info("{} written to {} as {}", sourcePath, destinationPath, compressFormat);
       }
     }
-
-    determineEndTime(execution, startTime);
   }
 
   public void setSource(Expression source) {

--- a/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/CompressFileDelegate.java
@@ -22,7 +22,6 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.Map;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
@@ -31,6 +30,7 @@ import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
 import org.folio.rest.camunda.exception.DelegateExecutionFailure;
+import org.folio.rest.camunda.utility.FileUtility;
 import org.folio.rest.workflow.enums.CompressFileContainer;
 import org.folio.rest.workflow.enums.CompressFileFormat;
 import org.folio.rest.workflow.model.CompressFileTask;
@@ -73,8 +73,11 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
   @Override
   protected void performExecute(DelegateExecution execution, String name, String id) {
 
-    String sourcePathTemplate = this.source.getValue(execution).toString();
-    String destinationPathTemplate = this.destination.getValue(execution).toString();
+    final Object sourcePathTemplateValue = this.source == null ? null : this.source.getValue(execution);
+    final Object destinationPathTemplateValue = this.destination == null ? null : this.destination.getValue(execution);
+
+    final String sourcePathTemplate = sourcePathTemplateValue == null ? "" : sourcePathTemplateValue.toString();
+    final String destinationPathTemplate = destinationPathTemplateValue == null ? "" : destinationPathTemplateValue.toString();
 
     StringTemplateLoader pathLoader = new StringTemplateLoader();
     pathLoader.putTemplate("sourcePath", sourcePathTemplate);
@@ -230,11 +233,12 @@ public class CompressFileDelegate extends AbstractWorkflowIODelegate {
   }
 
   private void setupEntryHeader(String path, String parentPath, TarArchiveOutputStream tar, File file) throws IOException {
-    Path filePath = Path.of(path);
-    TarArchiveEntry entry = new TarArchiveEntry(file, parentPath + file.getName());
+
+    final Path filePath = Path.of(path);
+    final TarArchiveEntry entry = FileUtility.createTarArchiveEntry(file, parentPath + file.getName());
 
     if (file.isFile()) {
-      entry.setSize(filesSize(Paths.get(path)));
+      entry.setSize(filesSize(filePath));
     }
 
     entry.setModTime(filesGetLastModifiedTime(filePath).toMillis());

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
@@ -1,6 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
 import java.util.Properties;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.workflow.model.DatabaseConnectionTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
@@ -19,15 +20,14 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
   private Expression password;
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     String urlValue = this.url.getValue(execution).toString();
     String key = this.designation.getValue(execution).toString();
@@ -36,7 +36,11 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
     info.setProperty("user", this.username.getValue(execution).toString());
     info.setProperty("password", this.password.getValue(execution).toString());
 
-    connectionService.createPool(key, urlValue, info);
+    try {
+      connectionService.createPool(key, urlValue, info);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
   }
 
   public void setUrl(Expression url) {

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseConnectionDelegate.java
@@ -1,9 +1,9 @@
 package org.folio.rest.camunda.delegate;
 
 import java.util.Properties;
+import org.folio.rest.workflow.model.DatabaseConnectionTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
-import org.folio.rest.workflow.model.DatabaseConnectionTask;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
@@ -18,9 +18,16 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
   private Expression username;
   private Expression password;
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     String urlValue = this.url.getValue(execution).toString();
     String key = this.designation.getValue(execution).toString();
@@ -30,8 +37,6 @@ public class DatabaseConnectionDelegate extends AbstractDatabaseDelegate {
     info.setProperty("password", this.password.getValue(execution).toString());
 
     connectionService.createPool(key, urlValue, info);
-
-    determineEndTime(execution, startTime);
   }
 
   public void setUrl(Expression url) {

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseDisconnectDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseDisconnectDelegate.java
@@ -1,5 +1,6 @@
 package org.folio.rest.camunda.delegate;
 
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.workflow.model.DatabaseDisconnectTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.springframework.context.annotation.Scope;
@@ -13,19 +14,22 @@ import org.springframework.stereotype.Service;
 public class DatabaseDisconnectDelegate extends AbstractDatabaseDelegate {
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     String key = this.designation.getValue(execution).toString();
 
-    connectionService.destroyConnection(key);
+    try {
+      connectionService.destroyConnection(key);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
   }
 
   @Override

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseDisconnectDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseDisconnectDelegate.java
@@ -1,7 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
-import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.folio.rest.workflow.model.DatabaseDisconnectTask;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
@@ -12,15 +12,20 @@ import org.springframework.stereotype.Service;
 @Scope("prototype")
 public class DatabaseDisconnectDelegate extends AbstractDatabaseDelegate {
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     String key = this.designation.getValue(execution).toString();
 
     connectionService.destroyConnection(key);
-
-    determineEndTime(execution, startTime);
   }
 
   @Override

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseQueryDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseQueryDelegate.java
@@ -38,9 +38,16 @@ public class DatabaseQueryDelegate extends AbstractDatabaseIODelegate {
 
   private Expression includeHeader;
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     String queryTemplate = this.query.getValue(execution).toString();
 
@@ -99,8 +106,6 @@ public class DatabaseQueryDelegate extends AbstractDatabaseIODelegate {
     } finally {
       conn.close();
     }
-
-    determineEndTime(execution, startTime);
   }
 
   public void setQuery(Expression query) {

--- a/src/main/java/org/folio/rest/camunda/delegate/DatabaseQueryDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/DatabaseQueryDelegate.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.workflow.model.DatabaseQueryTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
@@ -39,15 +40,14 @@ public class DatabaseQueryDelegate extends AbstractDatabaseIODelegate {
   private Expression includeHeader;
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     String queryTemplate = this.query.getValue(execution).toString();
 
@@ -59,15 +59,22 @@ public class DatabaseQueryDelegate extends AbstractDatabaseIODelegate {
 
     Map<String, Object> inputs = getInputs(execution);
 
-    String key = this.designation.getValue(execution).toString();
-    String queryValue = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("query"), inputs);
+    final String key = this.designation.getValue(execution).toString();
+    final String queryValue;
+
+    try {
+      queryValue = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("query"), inputs);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
 
     Boolean includeHeaderValue = this.includeHeader != null && this.includeHeader.getValue(execution) != null &&
       Boolean.parseBoolean(this.includeHeader.getValue(execution).toString());
 
-    Connection conn = connectionService.getConnection(key);
-
-    try (Statement statement = conn.createStatement()) {
+    try (
+      final Connection conn = connectionService.getConnection(key);
+      final Statement statement = conn.createStatement();
+     ) {
       statement.execute(queryValue);
 
       ResultSet results = null;
@@ -97,14 +104,15 @@ public class DatabaseQueryDelegate extends AbstractDatabaseIODelegate {
           if (hasOutputVariable(execution)) {
             setOutput(execution, count);
           } else {
-            getLogger().info("{} did not specify output variable for result count", getDelegateName(execution));
+            getLogger().info("{} did not specify output variable for result count", name);
           }
         }
 
         resultOp.finish();
       }
-    } finally {
-      conn.close();
+    }
+    catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
     }
   }
 

--- a/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
@@ -9,7 +9,7 @@ import jakarta.mail.internet.MimeMessage;
 import java.io.File;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.exception.EmailDelegateAddressFailure;
 import org.folio.rest.workflow.model.EmailTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -50,15 +50,14 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
   }
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     String subjectTemplate = this.mailSubject.getValue(execution).toString();
     String textTemplate = this.mailText.getValue(execution).toString();
@@ -80,18 +79,39 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
     Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
     cfg.setTemplateLoader(stringLoader);
 
-    Map<String, Object> inputs = getInputs(execution);
-    String subject = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("subject"), inputs);
-    String plainText = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("text"), inputs);
-    String htmlMarkup = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("markup"), inputs);
-    String to = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailTo"), inputs);
-    String from = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailFrom"), inputs);
+    final Map<String, Object> inputs = getInputs(execution);
+    final String subject;
+    final String plainText;
+    final String htmlMarkup;
+    final String to;
+    final String from;
+    final String cc;
+    final String bcc;
+    final String attachmentPathValue;
 
-    Optional<String> cc = Objects.nonNull(this.mailCc) ? Optional.ofNullable(this.mailCc.getValue(execution).toString()) : Optional.empty();
-    Optional<String> bcc = Objects.nonNull(this.mailBcc) ? Optional.ofNullable(this.mailBcc.getValue(execution).toString()) : Optional.empty();
-    Optional<String> attachmentPathValue = Objects.nonNull(this.attachmentPath) ? Optional.ofNullable(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("attachmentPath"), inputs)) : Optional.empty();
+    try {
+      subject = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("subject"), inputs);
+      plainText = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("text"), inputs);
+      htmlMarkup = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("markup"), inputs);
+      to = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailTo"), inputs);
+      from = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("mailFrom"), inputs);
 
-    getLogger().debug("E-mail To: {}, E-mail From: {}, E-mail Subject: {}, Has Attachment: {}", to, from, subject, attachmentPathValue.isPresent());
+      cc = mailCc == null
+        ? null
+        : mailCc.getValue(execution).toString();
+
+      bcc = mailBcc == null
+        ? null
+        : mailBcc.getValue(execution).toString();
+
+      attachmentPathValue = attachmentPath == null
+        ? null
+        : FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("attachmentPath"), inputs);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
+
+    getLogger().debug("E-mail To: {}, E-mail From: {}, E-mail Subject: {}, Has Attachment: {}", to, from, subject, attachmentPathValue == null ? "No" : "Yes");
 
     MimeMessagePreparator preparator = new MimeMessagePreparator() {
       public void prepare(MimeMessage mimeMessage) throws Exception {
@@ -123,8 +143,8 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
           message.setText(plainText, false);
         }
 
-        if (cc.isPresent()) {
-          for (String ccc : cc.get().split(",")) {
+        if (cc != null) {
+          for (String ccc : cc.split(",")) {
             try {
               message.addCc(ccc);
             } catch (AddressException e) {
@@ -133,8 +153,8 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
           }
         }
 
-        if (bcc.isPresent()) {
-          for (String cbcc : bcc.get().split(",")) {
+        if (bcc != null) {
+          for (String cbcc : bcc.split(",")) {
             try {
               message.addCc(cbcc);
             } catch (AddressException e) {
@@ -144,12 +164,12 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
         }
 
         // This is a hot fix to address an issue with the workflow not attaching e-mails.
-        if (attachmentPathValue.isPresent()) {
-          File attachment = createFile(attachmentPathValue.get());
+        if (attachmentPathValue != null) {
+          File attachment = createFile(attachmentPathValue);
           if (attachment.exists() && attachment.isFile()) {
             message.addAttachment(attachment.getName(), attachment);
           } else {
-            getLogger().info("{} does not exist", attachmentPathValue.get());
+            getLogger().info("{} does not exist", attachmentPathValue);
           }
         } else {
           getLogger().info("No attachment required");

--- a/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/EmailDelegate.java
@@ -49,9 +49,16 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
     this.emailSender = emailSender;
   }
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     String subjectTemplate = this.mailSubject.getValue(execution).toString();
     String textTemplate = this.mailText.getValue(execution).toString();
@@ -151,8 +158,6 @@ public class EmailDelegate extends AbstractWorkflowInputDelegate {
     };
 
     emailSender.send(preparator);
-
-    determineEndTime(execution, startTime);
   }
 
   public void setMailTo(Expression mailTo) {

--- a/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
@@ -17,10 +17,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.FileTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
+import org.operaton.bpm.model.bpmn.instance.FlowElement;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
@@ -32,6 +34,9 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
   private static final String LINE_KEY = "line";
   private static final String PATH_KEY = "path";
   private static final String TARGET_KEY = "target";
+
+  private static final String MSG_NOT_EXIST = "{} does not exist";
+  private static final String MSG_READ = "{} read";
 
   private Expression path;
 
@@ -45,34 +50,37 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
    * Perform the execution.
    *
    * @param execution The execution data.
+   *
+   * @throws Exception On error.
    */
   @Override
   public void execute(DelegateExecution execution) throws Exception {
 
     final FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
-    final String name = getDelegateName(execution);
+    final FlowElement flow = execution.getBpmnModelElementInstance();
+    final String name = flow.getName();
+    final String id = flow.getId();
     final long startTime = determineStartTime(execution, name, fileOp);
 
     try {
-      performExecute(execution, name);
+      performExecute(execution, name, id);
       determineEndTime(execution, startTime, name, false);
     } catch (Exception e) {
       determineEndTime(execution, startTime, name, true);
 
-      throw e;
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
     }
   }
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     final FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
 
@@ -88,38 +96,52 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
 
     Map<String, Object> inputs = getInputs(execution);
 
-    String filePath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(PATH_KEY), inputs);
-    Integer lineValue = Integer.parseInt(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(LINE_KEY), inputs));
+    final String filePath;
+    final Integer lineValue;
+    final File file;
 
-    File file = createFile(filePath);
+    try {
+      filePath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(PATH_KEY), inputs);
+      lineValue = Integer.parseInt(FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(LINE_KEY), inputs));
+      file = createFile(filePath);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
 
     switch (fileOp) {
       case COPY:
         if (file.exists()) {
-          String targetTemplate = this.target.getValue(execution).toString();
-          templateLoader.putTemplate(TARGET_KEY, targetTemplate);
-          String targetPath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(TARGET_KEY), inputs);
-
-          File targetFile = createFile(targetPath);
-
-          fileUtilsCopyFile(file, targetFile);
+          try {
+            String targetTemplate = this.target.getValue(execution).toString();
+            templateLoader.putTemplate(TARGET_KEY, targetTemplate);
+            String targetPath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(TARGET_KEY), inputs);
+  
+            File targetFile = createFile(targetPath);
+  
+            fileUtilsCopyFile(file, targetFile);
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+          }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 
       case MOVE:
         if (file.exists()) {
-          String targetTemplate = this.target.getValue(execution).toString();
-          templateLoader.putTemplate(TARGET_KEY, targetTemplate);
-          String targetPath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(TARGET_KEY), inputs);
-
-          File targetFile = createFile(targetPath);
-
-          FileUtils.moveFile(file, targetFile);
-
+          try {
+            String targetTemplate = this.target.getValue(execution).toString();
+            templateLoader.putTemplate(TARGET_KEY, targetTemplate);
+            String targetPath = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate(TARGET_KEY), inputs);
+  
+            File targetFile = createFile(targetPath);
+  
+            FileUtils.moveFile(file, targetFile);
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+          }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 
@@ -130,7 +152,7 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
             getLogger().info("{} has been deleted", filePath);
           }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 
@@ -139,10 +161,12 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
           try (BufferedReader reader = Files.newBufferedReader(Path.of(filePath), StandardCharsets.UTF_8)) {
             long lineCount = reader.lines().count();
             setOutput(execution, lineCount);
-            getLogger().info("{} read", filePath);
+            getLogger().info(MSG_READ, filePath);
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
           }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 
@@ -155,20 +179,26 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
             while ((currerntLine = reader.readLine()) != null && (++lineCount) < lineValue);
 
             setOutput(execution, currerntLine);
-            getLogger().info("{} read", filePath);
+            getLogger().info(MSG_READ, filePath);
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
           }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 
       case READ:
         if (file.exists()) {
-          String content = new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8);
-          setOutput(execution, content);
-          getLogger().info("{} read", filePath);
+          try {
+            String content = new String(Files.readAllBytes(Paths.get(filePath)), StandardCharsets.UTF_8);
+            setOutput(execution, content);
+            getLogger().info(MSG_READ, filePath);
+          } catch (Exception e) {
+            throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+          }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 
@@ -180,7 +210,7 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
         Object obj = inputs.get(targetInputVariable);
 
         if (obj == null) {
-          getLogger().warn("The target parameter '{}' of the WRITE operation is missing from the {} '{}'.", targetInputVariable, getDelegateClass(), getDelegateName(execution));
+          getLogger().warn("The target parameter '{}' of the WRITE operation is missing from the {} '{}'.", targetInputVariable, getDelegateClass(), name);
         } else if (obj instanceof List) {
           List<?> objects = (List<?>) obj;
           getLogger().info("{} {} has {} entries to write",
@@ -200,9 +230,15 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
           content.append(obj);
           content.append("\n");
         } else {
-          getLogger().warn("The target parameter '{}' of the WRITE operation is unsupported for the {} '{}'.", targetInputVariable, getDelegateClass(), getDelegateName(execution));
+          getLogger().warn("The target parameter '{}' of the WRITE operation is unsupported for the {} '{}'.", targetInputVariable, getDelegateClass(), name);
         }
-        FileUtils.writeStringToFile(file, content.toString(), StandardCharsets.UTF_8);
+
+        try {
+          FileUtils.writeStringToFile(file, content.toString(), StandardCharsets.UTF_8);
+        } catch (Exception e) {
+          throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+        }
+
         getLogger().info("{} written", filePath);
         break;
 
@@ -216,7 +252,7 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
             getLogger().info("{} is not a directory to list", filePath);
           }
         } else {
-          getLogger().info("{} does not exist", filePath);
+          getLogger().info(MSG_NOT_EXIST, filePath);
         }
         break;
 

--- a/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FileDelegate.java
@@ -41,10 +41,40 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
 
   private Expression target;
 
+  /**
+   * Perform the execution.
+   *
+   * @param execution The execution data.
+   */
   @Override
   public void execute(DelegateExecution execution) throws Exception {
+
     final FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
-    final long startTime = determineStartTime(execution, fileOp);
+    final String name = getDelegateName(execution);
+    final long startTime = determineStartTime(execution, name, fileOp);
+
+    try {
+      performExecute(execution, name);
+      determineEndTime(execution, startTime, name, false);
+    } catch (Exception e) {
+      determineEndTime(execution, startTime, name, true);
+
+      throw e;
+    }
+  }
+
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
+  @Override
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+
+    final FileOp fileOp = FileOp.valueOf(this.op.getValue(execution).toString());
 
     String pathTemplate = this.path.getValue(execution).toString();
     String lineTemplate = this.line != null ? this.line.getValue(execution).toString() : "0";
@@ -193,8 +223,6 @@ public class FileDelegate extends AbstractWorkflowIODelegate {
       default:
         break;
     }
-
-    determineEndTime(execution, startTime);
   }
 
   public void setPath(Expression path) {

--- a/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
@@ -37,9 +37,16 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
 
   private Expression password;
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     String originPathValue = this.originPath.getValue(execution).toString();
 
@@ -121,8 +128,6 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
       default:
         break;
     }
-
-    determineEndTime(execution, startTime);
   }
 
   public void setOriginPath(Expression originPath) {

--- a/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FtpDelegate.java
@@ -10,6 +10,7 @@ import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.Selectors;
 import org.apache.commons.vfs2.VFS;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.workflow.enums.SftpOp;
 import org.folio.rest.workflow.model.FtpTask;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -38,15 +39,14 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
   private Expression password;
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     String originPathValue = this.originPath.getValue(execution).toString();
 
@@ -68,7 +68,13 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
       ? Optional.ofNullable(this.password.getValue(execution).toString())
       : Optional.empty();
 
-    FileSystemManager manager = VFS.getManager();
+    final FileSystemManager manager;
+
+    try {
+      manager = VFS.getManager();
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
 
     String userInfo = null;
 
@@ -83,48 +89,66 @@ public class FtpDelegate extends AbstractWorkflowIODelegate {
     switch (opValue) {
       case GET: {
 
-        File file = createFile(destinationPathValue);
+        final File file = createFile(destinationPathValue);
+        final URI uri;
 
-        URI uri = new URI(
-          schemeValue,
-          userInfo,
-          hostValue,
-          portValue,
-          originPathValue,
-          null,
-          null
-        );
+        try {
+          uri = new URI(
+            schemeValue,
+            userInfo,
+            hostValue,
+            portValue,
+            originPathValue,
+            null,
+            null
+          );
+        } catch (Exception e) {
+          throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+        }
 
         try (
-          FileObject local = manager.resolveFile(file.getAbsolutePath());
-          FileObject remote = manager.resolveFile(uri);
+          final FileObject local = manager.resolveFile(file.getAbsolutePath());
+          final FileObject remote = manager.resolveFile(uri);
         ) {
           local.copyFrom(remote, Selectors.SELECT_SELF);
+        } catch (Exception e) {
+          throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
         }
 
-      } break;
+        break;
+      }
+
       case PUT: {
 
-        File file = createFile(originPathValue);
+        final File file = createFile(originPathValue);
+        final URI uri;
 
-        URI uri = new URI(
-          schemeValue,
-          userInfo,
-          hostValue,
-          portValue,
-          destinationPathValue,
-          null,
-          null
-        );
-
-        try (
-          FileObject local = manager.resolveFile(file.getAbsolutePath());
-          FileObject remote = manager.resolveFile(uri);
-        ) {
-          remote.copyFrom(local, Selectors.SELECT_SELF);
+        try {
+          uri = new URI(
+            schemeValue,
+            userInfo,
+            hostValue,
+            portValue,
+            destinationPathValue,
+            null,
+            null
+          );
+        } catch (Exception e) {
+          throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
         }
 
-      } break;
+        try (
+          final FileObject local = manager.resolveFile(file.getAbsolutePath());
+          final FileObject remote = manager.resolveFile(uri);
+        ) {
+          remote.copyFrom(local, Selectors.SELECT_SELF);
+        } catch (Exception e) {
+          throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+        }
+
+        break;
+      }
+
       default:
         break;
     }

--- a/src/main/java/org/folio/rest/camunda/delegate/InputDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/InputDelegate.java
@@ -21,15 +21,14 @@ public class InputDelegate extends AbstractWorkflowIODelegate {
   }
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
     // Should be empty.
   }
 

--- a/src/main/java/org/folio/rest/camunda/delegate/InputDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/InputDelegate.java
@@ -1,7 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
-import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.folio.rest.workflow.model.InputTask;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
@@ -13,14 +13,24 @@ public class InputDelegate extends AbstractWorkflowIODelegate {
   @Value("${okapi.url}")
   private String okapiUrl;
 
+  /**
+   * Initializer.
+   */
   public InputDelegate() {
+    // Should be empty.
   }
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
-
-    determineEndTime(execution, startTime);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    // Should be empty.
   }
 
   @Override

--- a/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
@@ -1,6 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
 import java.util.Map;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.folio.rest.workflow.model.ProcessorTask;
@@ -21,15 +22,14 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
   private Expression processor;
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     EmbeddedProcessor processorValue = mapper.readValue(this.processor.getValue(execution).toString(), EmbeddedProcessor.class);
 
@@ -41,9 +41,13 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
 
     JsonNode input = mapper.valueToTree(inputs);
 
-    String output = (String) scriptEngineService.runScript(scriptTypeExtension, scriptName, input);
-
-    setOutput(execution, output);
+    try {
+      final String output = (String) scriptEngineService.runScript(scriptTypeExtension, scriptName, input);
+  
+      setOutput(execution, output);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
   }
 
   public void setProcessor(Expression processor) {

--- a/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/ProcessorDelegate.java
@@ -20,9 +20,16 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
 
   private Expression processor;
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
     EmbeddedProcessor processorValue = mapper.readValue(this.processor.getValue(execution).toString(), EmbeddedProcessor.class);
 
@@ -37,8 +44,6 @@ public class ProcessorDelegate extends AbstractWorkflowIODelegate {
     String output = (String) scriptEngineService.runScript(scriptTypeExtension, scriptName, input);
 
     setOutput(execution, output);
-
-    determineEndTime(execution, startTime);
   }
 
   public void setProcessor(Expression processor) {

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -228,10 +228,8 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
 
     if (TRACE.equals(method)) return false;
 
-    if (body == null || body.isEmpty()) {
-      if (DELETE.equals(method) || GET.equals(method) || HEAD.equals(method)) {
-        return Boolean.TRUE.equals(sendEmptyBody);
-      }
+    if ((body == null || body.isEmpty()) && (DELETE.equals(method) || GET.equals(method) || HEAD.equals(method))) {
+      return Boolean.TRUE.equals(sendEmptyBody);
     }
 
     return true;

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.exception.DelegateSpinFailure;
 import org.folio.rest.workflow.dto.Request;
 import org.folio.rest.workflow.enums.VariableType;
@@ -67,15 +68,14 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
   }
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     final Request requestValue = mapper.readValue(this.request.getValue(execution).toString(), Request.class);
 
@@ -95,10 +95,20 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
     if (bodyTemplate != null) {
       stringLoader.putTemplate("body", requestValue.getBodyTemplate());
 
-      body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+      try {
+        body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+      } catch (Exception e) {
+        throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+      }
     }
 
-    final String url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+    final String url;
+
+    try {
+      url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+    } catch (Exception e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
 
     final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
     final String accept = requestValue.getAccept();

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -1,13 +1,16 @@
 package org.folio.rest.camunda.delegate;
 
 import static org.operaton.spin.Spin.JSON;
+import static org.springframework.http.HttpMethod.DELETE;
+import static org.springframework.http.HttpMethod.GET;
+import static org.springframework.http.HttpMethod.HEAD;
+import static org.springframework.http.HttpMethod.TRACE;
 
 import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.folio.rest.camunda.exception.DelegateSpinFailure;
 import org.folio.rest.workflow.dto.Request;
@@ -45,99 +48,6 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
     this.httpService = httpService;
   }
 
-  @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
-
-    Request requestValue = mapper.readValue(this.request.getValue(execution).toString(), Request.class);
-
-    Map<String, Object> inputs = getInputs(execution);
-
-    Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
-
-    StringTemplateLoader stringLoader = new StringTemplateLoader();
-    stringLoader.putTemplate("url", requestValue.getUrl());
-    stringLoader.putTemplate("body", requestValue.getBodyTemplate());
-    cfg.setTemplateLoader(stringLoader);
-
-    String url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
-    String body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
-
-    HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
-    String accept = requestValue.getAccept();
-    String contentType = requestValue.getContentType();
-
-    String tenant = execution.getTenantId();
-
-    Optional<Object> token = Optional.ofNullable(execution.getVariable("X-Okapi-Token"));
-
-    getLogger().info("url: {}", url);
-    getLogger().debug("method: {}", method);
-
-    getLogger().debug("accept: {}", accept);
-    getLogger().debug("content-type: {}", contentType);
-    getLogger().debug("tenant: {}", tenant);
-
-    HttpHeaders headers = new HttpHeaders();
-    headers.add("Accept", accept);
-    headers.add("Content-Type", contentType);
-    headers.add("X-Okapi-Tenant", tenant);
-    headers.add("X-Okapi-Url", okapiUrl);
-
-    if (token.isPresent()) {
-      headers.add("X-Okapi-Token", token.get().toString());
-    }
-
-    HttpEntity<Object> entity = new HttpEntity<>(body, headers);
-    ResponseEntity<Object> response = httpService.exchange(url, method, entity, Object.class);
-
-    setOutput(execution, response.getBody());
-
-    getHeaderOutputVariables(execution).forEach(headerOutputVariable -> {
-      if (headerOutputVariable.getKey() != null) {
-        VariableType type = headerOutputVariable.getType();
-        String key = headerOutputVariable.getKey();
-
-        if (response.getHeaders().containsHeader(key)) {
-          if (type != null) {
-            Object value = null;
-
-            if (headerOutputVariable.getAsArray()) {
-              List<String> valueList = new ArrayList<>();
-
-              if (response.getHeaders().containsHeader(key)) {
-                valueList.addAll(response.getHeaders().get(key));
-              }
-
-              value = spinValue(headerOutputVariable, valueList);
-            } else {
-              value = spinValue(headerOutputVariable, response.getHeaders().getFirst(key));
-            }
-
-            switch (type) {
-              case LOCAL:
-                execution.setVariableLocal(key, value);
-                break;
-              case PROCESS:
-                execution.setVariable(key, value);
-                break;
-              default:
-                break;
-            }
-          } else {
-            getLogger().warn("Variable type not present for {}.", key);
-          }
-        } else {
-          getLogger().warn("Header output not present for {}.", key);
-        }
-      } else {
-        getLogger().warn("Header output key is not found in the response.");
-      }
-    });
-
-    determineEndTime(execution, startTime);
-  }
-
   public void setRequest(Expression request) {
     this.request = request;
   }
@@ -152,10 +62,169 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
   }
 
   public Set<EmbeddedVariable> getHeaderOutputVariables(DelegateExecution execution) throws JacksonException {
-    // @formatter:off
     return mapper.readValue(headerOutputVariables.getValue(execution).toString(),
-        new TypeReference<Set<EmbeddedVariable>>() {});
-    // @formatter:on
+      new TypeReference<Set<EmbeddedVariable>>() {});
+  }
+
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
+  @Override
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+
+    final Request requestValue = mapper.readValue(this.request.getValue(execution).toString(), Request.class);
+
+    final Map<String, Object> inputs = getInputs(execution);
+    final Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
+
+    final String bodyTemplate = requestValue.getBodyTemplate();
+    final Boolean sendEmptyBody = requestValue.getSendEmptyBody();
+
+    final StringTemplateLoader stringLoader = new StringTemplateLoader();
+    stringLoader.putTemplate("url", requestValue.getUrl());
+
+    cfg.setTemplateLoader(stringLoader);
+
+    String body = null;
+
+    if (bodyTemplate != null) {
+      stringLoader.putTemplate("body", requestValue.getBodyTemplate());
+
+      body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+    }
+
+    final String url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+
+    final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
+    final String accept = requestValue.getAccept();
+    final String contentType = requestValue.getContentType();
+
+    final String tenant = execution.getTenantId();
+    final Object token = execution.getVariable("X-Okapi-Token");
+
+    getLogger().info("url: {}", url);
+    getLogger().debug("method: {}", method);
+    getLogger().debug("sendEmptyBody: {}", sendEmptyBody);
+
+    getLogger().debug("accept: {}", accept);
+    getLogger().debug("content-type: {}", contentType);
+    getLogger().debug("tenant: {}", tenant);
+
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add("Accept", accept);
+    headers.add("Content-Type", contentType);
+    headers.add("X-Okapi-Tenant", tenant);
+    headers.add("X-Okapi-Url", okapiUrl);
+
+    if (token != null) {
+      headers.add("X-Okapi-Token", token.toString());
+    }
+
+    final HttpEntity<Object> entity = shouldSendBody(body, sendEmptyBody, method)
+      ? new HttpEntity<>(body, headers)
+      : new HttpEntity<>(headers);
+
+    final ResponseEntity<Object> response = httpService.exchange(url, method, entity, Object.class);
+
+    setOutput(execution, response.getBody());
+
+    getHeaderOutputVariables(execution)
+      .forEach(headerOutputVariable -> performExecuteHeaderOutputVariables(execution, headerOutputVariable, response));
+  }
+
+  /**
+   * Perform the delegate execution relating to header output variables.
+   *
+   * @param execution            The delegate execution data.
+   * @param headerOutputVariable The embedded variable.
+   */
+  private void performExecuteHeaderOutputVariables(
+    final DelegateExecution execution, final EmbeddedVariable headerOutputVariable, final ResponseEntity<Object> response
+  ) {
+
+    if (headerOutputVariable.getKey() != null) {
+      VariableType type = headerOutputVariable.getType();
+      String key = headerOutputVariable.getKey();
+
+      if (response.getHeaders().containsHeader(key)) {
+        if (type != null) {
+          final Object value = performExecuteHeaderOutputVariablesSpin(headerOutputVariable, response.getHeaders(), key);
+
+          switch (type) {
+            case LOCAL:
+              execution.setVariableLocal(key, value);
+              break;
+            case PROCESS:
+              execution.setVariable(key, value);
+              break;
+            default:
+              break;
+          }
+        } else {
+          getLogger().warn("Variable type not present for {}.", key);
+        }
+      } else {
+        getLogger().warn("Header output not present for {}.", key);
+      }
+    } else {
+      getLogger().warn("Header output key is not found in the response.");
+    }
+  }
+
+  /**
+   * Perform the delegate execution relating to header output variables for spin.
+   *
+   * @param headerOutputVariable The embedded variable.
+   * @param headers              The HTTP headers.
+   * @param key                  The key representing the array index.
+   *
+   * @return The value, after "spinning".
+   */
+  private Object performExecuteHeaderOutputVariablesSpin(final EmbeddedVariable headerOutputVariable, final HttpHeaders headers, final String key) {
+
+    if (Boolean.TRUE.equals(headerOutputVariable.getAsArray())) {
+      final List<String> valueList = new ArrayList<>();
+
+      if (headers.containsHeader(key)) {
+        valueList.addAll(headers.get(key));
+      }
+
+      return spinValue(headerOutputVariable, valueList);
+    }
+
+    return spinValue(headerOutputVariable, headers.getFirst(key));
+  }
+
+  /**
+   * Determine if HTML body section should be sent or not.
+   *
+   * The body string, the HTTP method, and the sendEmptyBody are all used to determine whether or not the body should be sent.
+   * If this returns true, then the body should be sent regardless of whether or not it is NULL or some string.
+   *
+   * The HTTP TRACE must never send an HTTP body section.
+   *
+   * @param body          The body string.
+   * @param sendEmptyBody Whether or not to send an empty body.
+   * @param method        The HTTP Method.
+   *
+   * @return TRUE on send body and FALSE otherwise.
+   */
+  private boolean shouldSendBody(final String body, final Boolean sendEmptyBody, final HttpMethod method) {
+
+    if (TRACE.equals(method)) return false;
+
+    if (body == null || body.isEmpty()) {
+      if (DELETE.equals(method) || GET.equals(method) || HEAD.equals(method)) {
+        return Boolean.TRUE.equals(sendEmptyBody);
+      }
+    }
+
+    return true;
   }
 
   /**
@@ -170,7 +239,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    */
   private Object spinValue(EmbeddedVariable variable, Object value) throws DelegateSpinFailure {
     try {
-      return variable.getSpin() ? JSON(mapper.writeValueAsString(value)) : value;
+      return Boolean.TRUE.equals(variable.getSpin()) ? JSON(mapper.writeValueAsString(value)) : value;
     } catch (JacksonException e) {
       throw new DelegateSpinFailure(variable.getKey(), RequestDelegate.class.getName(), e);
     }

--- a/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
@@ -4,11 +4,11 @@ import static org.operaton.spin.Spin.JSON;
 
 import java.util.List;
 import java.util.Map;
+import org.folio.rest.camunda.service.ScriptEngineService;
+import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.spin.json.SpinJsonNode;
-import org.folio.rest.camunda.service.ScriptEngineService;
-import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
@@ -28,11 +28,18 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
 
   private Expression processors;
 
+  /**
+   * Perform the delegate execution.
+   *
+   * @param execution The delegate execution data.
+   * @param name      The delegate name.
+   *
+   * @throws Exception On any error.
+   */
   @Override
-  public void execute(DelegateExecution execution) throws Exception {
-    final long startTime = determineStartTime(execution);
+  protected void performExecute(DelegateExecution execution, String name) throws Exception {
 
-    getLogger().info("loading initial context");
+    getLogger().info("loading initial context with definition id {}", execution.getProcessDefinitionId());
 
     Map<String, Object> context = mapper.readValue(initialContext.getValue(execution).toString(),
       new TypeReference<Map<String, Object>>() {
@@ -62,8 +69,6 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
       scriptEngineService.registerScript(extension, functionName, code);
       getLogger().info("{}: {}", processor.getFunctionName(), processor.getCode());
     }
-
-    determineEndTime(execution, startTime);
   }
 
   public void setInitialContext(Expression initialContext) {

--- a/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/SetupDelegate.java
@@ -4,6 +4,7 @@ import static org.operaton.spin.Spin.JSON;
 
 import java.util.List;
 import java.util.Map;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -29,15 +30,14 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
   private Expression processors;
 
   /**
-   * Perform the delegate execution.
+   * Perform the execution.
    *
-   * @param execution The delegate execution data.
+   * @param execution The execution data.
    * @param name      The delegate name.
-   *
-   * @throws Exception On any error.
+   * @param id        The delegate ID.
    */
   @Override
-  protected void performExecute(DelegateExecution execution, String name) throws Exception {
+  protected void performExecute(DelegateExecution execution, String name, String id) {
 
     getLogger().info("loading initial context with definition id {}", execution.getProcessDefinitionId());
 
@@ -66,8 +66,13 @@ public class SetupDelegate extends AbstractRuntimeDelegate {
       String extension = processor.getScriptType().getExtension();
       String functionName = processor.getFunctionName();
       String code = processor.getCode();
-      scriptEngineService.registerScript(extension, functionName, code);
-      getLogger().info("{}: {}", processor.getFunctionName(), processor.getCode());
+
+      try {
+        scriptEngineService.registerScript(extension, functionName, code);
+        getLogger().info("{}: {}", processor.getFunctionName(), processor.getCode());
+      } catch (Exception e) {
+        throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+      }
     }
   }
 

--- a/src/main/java/org/folio/rest/camunda/exception/DelegateExecutionFailure.java
+++ b/src/main/java/org/folio/rest/camunda/exception/DelegateExecutionFailure.java
@@ -1,0 +1,17 @@
+package org.folio.rest.camunda.exception;
+
+public class DelegateExecutionFailure extends RuntimeException {
+
+  private static final long serialVersionUID = 4525720846209903267L;
+
+  private static final String MESSAGE = "Failed to execute delegate %s (ID %s), reason: %s.";
+
+  public DelegateExecutionFailure(String name, String id, String reason) {
+    super(String.format(MESSAGE, name, id, reason));
+  }
+
+  public DelegateExecutionFailure(String name, String id, String reason, Exception e) {
+    super(String.format(MESSAGE, name, id, reason), e);
+  }
+
+}

--- a/src/main/java/org/folio/rest/camunda/exception/RequestMissingWorkflowException.java
+++ b/src/main/java/org/folio/rest/camunda/exception/RequestMissingWorkflowException.java
@@ -1,0 +1,31 @@
+package org.folio.rest.camunda.exception;
+
+/**
+ * Designate a bad request due to missing Workflow.
+ */
+public class RequestMissingWorkflowException extends RuntimeException {
+
+  private static final long serialVersionUID = 2234332019817219L;
+
+  private static final String MSG = "No workflow has been specified for the %s request.";
+
+  /**
+   * Designate a bad request regarding the specified request end point.
+   *
+   * @param request The request end point.
+   */
+  public RequestMissingWorkflowException(String request) {
+    super(String.format(MSG, request));
+  }
+
+  /**
+   * Designate a bad request regarding the specified request end point.
+   *
+   * @param request The request end point.
+   * @param e       An associated exception.
+   */
+  public RequestMissingWorkflowException(String request, Exception e) {
+    super(String.format(MSG, request), e);
+  }
+
+}

--- a/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
+++ b/src/main/java/org/folio/rest/camunda/service/BpmnModelFactory.java
@@ -585,11 +585,13 @@ public class BpmnModelFactory {
       } else if (node instanceof Subprocess subprocess) {
         scripts.addAll(getProcessorScripts(workflow, subprocess.getNodes()));
       } else if (node instanceof Task) {
-        logger.warn("A Process Script named {} for Workflow '{}' ({}) is a non-processor task.", node.getName(), workflow.getName(), workflow.getId());
+        logger.debug("A Process Script named {} for Workflow '{}' ({}) is a non-processor task ({}).", node.getName(), workflow.getName(), workflow.getId(), node.getClass().getSimpleName());
+      } else if (node instanceof Event) {
+        logger.debug("A Process Script named {} for Workflow '{}' ({}) is a non-processor event ({}).", node.getName(), workflow.getName(), workflow.getId(), node.getClass().getSimpleName());
       } else if (node == null) {
         throw new BpmnModelFailure(String.format("A Process Script Node for Workflow '%s' (%s) is NULL.", workflow.getName(), workflow.getId()));
       } else {
-        logger.warn("A Process Script named {} for Workflow '{}' ({}) is of an unknown type.", node.getName(), workflow.getName(), workflow.getId());
+        logger.warn("A Process Script named {} for Workflow '{}' ({}) is of an unknown type ({}).", node.getName(), workflow.getName(), workflow.getId(), node.getClass().getSimpleName());
       }
     });
 

--- a/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
@@ -1,5 +1,6 @@
 package org.folio.rest.camunda.service;
 
+import org.folio.rest.camunda.exception.RequestMissingWorkflowException;
 import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.camunda.utility.LoggerStream;
@@ -41,6 +42,10 @@ public class CamundaApiService {
   public Workflow deployWorkflow(Workflow workflow, String tenant)
       throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
 
+    if (workflow == null) {
+      throw new RequestMissingWorkflowException("deploy");
+    }
+
     if (Boolean.TRUE.equals(workflow.getActive())) {
       throw new WorkflowAlreadyActiveException(workflow.getId());
     }
@@ -74,6 +79,11 @@ public class CamundaApiService {
   }
 
   public Workflow undeployWorkflow(Workflow workflow) {
+
+    if (workflow == null) {
+      throw new RequestMissingWorkflowException("undeploy");
+    }
+
     if (Boolean.FALSE.equals(workflow.getActive())) {
       return workflow;
     }

--- a/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
+++ b/src/main/java/org/folio/rest/camunda/service/CamundaApiService.java
@@ -1,5 +1,9 @@
 package org.folio.rest.camunda.service;
 
+import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
+import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
+import org.folio.rest.camunda.utility.LoggerStream;
+import org.folio.rest.workflow.model.Workflow;
 import org.operaton.bpm.engine.AuthorizationException;
 import org.operaton.bpm.engine.ParseException;
 import org.operaton.bpm.engine.ProcessEngine;
@@ -10,12 +14,9 @@ import org.operaton.bpm.engine.exception.NotValidException;
 import org.operaton.bpm.engine.repository.Deployment;
 import org.operaton.bpm.model.bpmn.Bpmn;
 import org.operaton.bpm.model.bpmn.BpmnModelInstance;
-import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
-import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
-import org.folio.rest.workflow.model.Workflow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.event.Level;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,13 +24,28 @@ public class CamundaApiService {
 
   private static final Logger logger = LoggerFactory.getLogger(CamundaApiService.class);
 
-  @Autowired
+  private static final LoggerStream debugStream = new LoggerStream(logger, Level.DEBUG);
+
   private BpmnModelFactory bpmnModelFactory;
 
-  public Workflow deployWorkflow(Workflow workflow, String tenant) throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
+  /**
+   * Initializer.
+   *
+   * @param bpmnModelFactory The model factory.
+   */
+  public CamundaApiService(BpmnModelFactory bpmnModelFactory) {
+
+    this.bpmnModelFactory = bpmnModelFactory;
+  }
+
+  public Workflow deployWorkflow(Workflow workflow, String tenant)
+      throws WorkflowAlreadyActiveException, ScriptTaskDeserializeCodeFailure {
+
     if (Boolean.TRUE.equals(workflow.getActive())) {
       throw new WorkflowAlreadyActiveException(workflow.getId());
     }
+
+    logger.info("Deploying BPMN Model for Workflow '{}' with ID '{}'.", workflow.getName(), workflow.getId());
 
     BpmnModelInstance modelInstance = bpmnModelFactory.fromWorkflow(workflow);
 
@@ -49,12 +65,7 @@ public class CamundaApiService {
       workflow.setActive(true);
       workflow.setDeploymentId(deploymentId);
     } catch (NotFoundException | NotValidException | ParseException | AuthorizationException e) {
-      // TODO: find a way to write the stream to the logger rather than using System.out.
-      // Display the model while in debug mode to help identify model problems.
-      // This should never be displayed outside of debug and the exception is bubbled up.
-      if (logger.isDebugEnabled()) {
-        Bpmn.writeModelToStream(System.out, modelInstance);
-      }
+      Bpmn.writeModelToStream(debugStream, modelInstance);
 
       throw e;
     }

--- a/src/main/java/org/folio/rest/camunda/utility/FileUtility.java
+++ b/src/main/java/org/folio/rest/camunda/utility/FileUtility.java
@@ -14,6 +14,7 @@ import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.zip.ZipOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.CompressorException;
 import org.apache.commons.compress.compressors.CompressorOutputStream;
@@ -110,6 +111,19 @@ public class FileUtility {
   public static FileInputStream createFileInputStream(File file) throws FileNotFoundException {
 
     return new FileInputStream(file);
+  }
+
+  /**
+   * Wrap new TarArchiveEntry() method in such a way that unit tests can be more easily written.
+   *
+   * @param file The file.
+   * @param name The file name.
+   *
+   * @return The new TarArchiveEntry.
+   */
+  public static TarArchiveEntry createTarArchiveEntry(File file, String name) {
+
+    return new TarArchiveEntry(file, name);
   }
 
   /**

--- a/src/main/java/org/folio/rest/camunda/utility/LoggerStream.java
+++ b/src/main/java/org/folio/rest/camunda/utility/LoggerStream.java
@@ -1,0 +1,54 @@
+package org.folio.rest.camunda.utility;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+import org.slf4j.spi.LoggingEventBuilder;
+
+/**
+ * Provide a means to expose SLF4J logging to BPMN.
+ */
+public class LoggerStream extends OutputStream {
+
+  private final ByteArrayOutputStream stream;
+
+  private LoggingEventBuilder builder;
+
+  public LoggerStream(Logger logger, Level level) {
+
+    builder = logger.atLevel(level);
+    stream = new ByteArrayOutputStream();
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+
+    stream.write(b);
+  }
+
+  @Override
+  public void write(byte[] bytes, int off, int length) throws IOException {
+
+    Objects.checkFromIndexSize(off, length, bytes.length);
+
+    // The length == 0 condition is implicitly handled by loop bounds.
+    for (int i = 0 ; i < length ; i++) {
+        write(bytes[off + i]);
+    }
+  }
+
+  @Override
+  public void flush() {
+
+    if (stream.size() > 0) {
+      final String output = stream.toString();
+
+      stream.reset();
+      builder.log(output);
+    }
+  }
+
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -10,6 +10,7 @@ logging:
       folio: INFO
       hibernate: INFO
       operaton: INFO
+      operaton.bpm.engine.jobexecutor: ERROR
       springframework: INFO
 
     # Enable logging of BPMN if activation fails.

--- a/src/test/java/org/folio/rest/camunda/aspect/TenantInjectionDelegateAspectTest.java
+++ b/src/test/java/org/folio/rest/camunda/aspect/TenantInjectionDelegateAspectTest.java
@@ -1,18 +1,18 @@
 package org.folio.rest.camunda.aspect;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.operaton.bpm.engine.delegate.DelegateExecution;
-import org.operaton.bpm.engine.delegate.DelegateTask;
 import org.folio.spring.tenant.exception.NoTenantException;
 import org.folio.spring.tenant.properties.TenantProperties;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
+import org.operaton.bpm.engine.delegate.DelegateTask;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @ExtendWith(SpringExtension.class)
@@ -38,7 +38,7 @@ class TenantInjectionDelegateAspectTest {
     when(execution.getTenantId()).thenReturn(MOCK_TENANT);
     tenantInjectionDelegateAspect.beforeDelegateExecution(execution);
 
-    Mockito.verify(execution).getTenantId();
+    verify(execution).getTenantId();
 
     when(execution.getTenantId()).thenReturn(null);
     when(tenantProperties.isForceTenant()).thenReturn(true);
@@ -50,7 +50,7 @@ class TenantInjectionDelegateAspectTest {
     when(execution.getTenantId()).thenReturn(MOCK_TENANT);
     tenantInjectionDelegateAspect.beforeExecutionListenerNotify(execution);
 
-    Mockito.verify(execution).getTenantId();
+    verify(execution).getTenantId();
 
     when(execution.getTenantId()).thenReturn(null);
     when(tenantProperties.isForceTenant()).thenReturn(true);
@@ -62,7 +62,7 @@ class TenantInjectionDelegateAspectTest {
     when(task.getTenantId()).thenReturn(MOCK_TENANT);
     tenantInjectionDelegateAspect.beforeTaskListenerNotify(task);
 
-    Mockito.verify(task).getTenantId();
+    verify(task).getTenantId();
 
     when(task.getTenantId()).thenReturn(null);
     when(tenantProperties.isForceTenant()).thenReturn(true);

--- a/src/test/java/org/folio/rest/camunda/controller/advice/AbstractAdviceTest.java
+++ b/src/test/java/org/folio/rest/camunda/controller/advice/AbstractAdviceTest.java
@@ -2,13 +2,13 @@ package org.folio.rest.camunda.controller.advice;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import org.folio.spring.test.helper.MapperHelper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -28,7 +28,7 @@ class AbstractAdviceTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
     abstractAdvice = new MockAdvice();
   }
 

--- a/src/test/java/org/folio/rest/camunda/controller/advice/GlobalAdviceTest.java
+++ b/src/test/java/org/folio/rest/camunda/controller/advice/GlobalAdviceTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.camunda.controller.advice;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.folio.rest.camunda.exception.BpmnModelFailure;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.exception.DelegateSpinFailure;
 import org.folio.rest.camunda.exception.EmailDelegateAddressFailure;
 import org.folio.rest.camunda.exception.ScriptEngineLoadFailed;
@@ -22,6 +23,9 @@ class GlobalAdviceTest {
 
   @Mock
   private BpmnModelFailure bpmnModelFailure;
+
+  @Mock
+  private DelegateExecutionFailure delegateExecutionFailure;
 
   @Mock
   private DelegateSpinFailure delegateSpinFailure;
@@ -49,6 +53,13 @@ class GlobalAdviceTest {
   @Test
   void handleBpmnModelFailureTest() {
     ResponseEntity<String> response = globalAdvice.handleBpmnModelFailure(bpmnModelFailure);
+
+    assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+  @Test
+  void handleDelegateExecutionFailureTest() {
+    ResponseEntity<String> response = globalAdvice.handleDelegateExecutionFailure(delegateExecutionFailure);
 
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
   }

--- a/src/test/java/org/folio/rest/camunda/controller/advice/GlobalAdviceTest.java
+++ b/src/test/java/org/folio/rest/camunda/controller/advice/GlobalAdviceTest.java
@@ -6,6 +6,7 @@ import org.folio.rest.camunda.exception.BpmnModelFailure;
 import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.exception.DelegateSpinFailure;
 import org.folio.rest.camunda.exception.EmailDelegateAddressFailure;
+import org.folio.rest.camunda.exception.RequestMissingWorkflowException;
 import org.folio.rest.camunda.exception.ScriptEngineLoadFailed;
 import org.folio.rest.camunda.exception.ScriptEngineUnsupported;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
@@ -32,6 +33,9 @@ class GlobalAdviceTest {
 
   @Mock
   private EmailDelegateAddressFailure emailDelegateAddressFailure;
+
+  @Mock
+  private RequestMissingWorkflowException requestMissingWorkflowException;
 
   @Mock
   private ScriptEngineLoadFailed scriptEngineLoadFailed;
@@ -76,6 +80,13 @@ class GlobalAdviceTest {
     ResponseEntity<String> response = globalAdvice.handleEmailDelegateAddressFailure(emailDelegateAddressFailure);
 
     assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+  }
+
+  @Test
+  void handleRequestMissingWorkflowExceptionTest() {
+    ResponseEntity<String> response = globalAdvice.handleRequestMissingWorkflowException(requestMissingWorkflowException);
+
+    assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseDelegateTest.java
@@ -32,7 +32,7 @@ class AbstractDatabaseDelegateTest {
   private static class Impl extends AbstractDatabaseDelegate {
 
     @Override
-    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name, String id) {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseDelegateTest.java
@@ -4,13 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
-import org.operaton.bpm.engine.delegate.DelegateExecution;
-import org.operaton.bpm.engine.delegate.Expression;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
+import org.operaton.bpm.engine.delegate.Expression;
 
 @ExtendWith(MockitoExtension.class)
 class AbstractDatabaseDelegateTest {
@@ -32,7 +32,8 @@ class AbstractDatabaseDelegateTest {
   private static class Impl extends AbstractDatabaseDelegate {
 
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+      // This is a test and should not do anything.
     }
 
     @Override

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseIODelegateTest.java
@@ -107,7 +107,7 @@ class AbstractDatabaseIODelegateTest {
   private static class Impl extends AbstractDatabaseIODelegate {
 
     @Override
-    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name, String id) {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseIODelegateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -41,7 +41,7 @@ class AbstractDatabaseIODelegateTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDatabaseIODelegateTest.java
@@ -107,7 +107,7 @@ class AbstractDatabaseIODelegateTest {
   private static class Impl extends AbstractDatabaseIODelegate {
 
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name) throws Exception {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
@@ -1,12 +1,12 @@
 package org.folio.rest.camunda.delegate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import org.folio.spring.test.helper.MapperHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -23,7 +23,7 @@ class AbstractDelegateTest {
   private Impl abstractDelegate;
 
   public void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
@@ -51,7 +51,7 @@ class AbstractDelegateTest {
   private static class Impl extends AbstractDelegate {
 
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name) throws Exception {
       // This is a test and should not do anything.
     }
   }

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractDelegateTest.java
@@ -51,7 +51,7 @@ class AbstractDelegateTest {
   private static class Impl extends AbstractDelegate {
 
     @Override
-    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name, String id) {
       // This is a test and should not do anything.
     }
   }

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
@@ -110,7 +110,7 @@ class AbstractWorkflowIODelegateTest {
   private static class Impl extends AbstractWorkflowIODelegate {
 
     @Override
-    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name, String id) {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -44,7 +44,7 @@ class AbstractWorkflowIODelegateTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowIODelegateTest.java
@@ -110,7 +110,7 @@ class AbstractWorkflowIODelegateTest {
   private static class Impl extends AbstractWorkflowIODelegate {
 
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name) throws Exception {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
@@ -108,7 +108,7 @@ class AbstractWorkflowInputDelegateTest {
   private static class Impl extends AbstractWorkflowInputDelegate {
 
     @Override
-    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name, String id) {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -20,7 +21,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -44,7 +44,7 @@ class AbstractWorkflowInputDelegateTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowInputDelegateTest.java
@@ -108,7 +108,7 @@ class AbstractWorkflowInputDelegateTest {
   private static class Impl extends AbstractWorkflowInputDelegate {
 
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name) throws Exception {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
@@ -99,7 +99,7 @@ class AbstractWorkflowOutputDelegateTest {
   private static class Impl extends AbstractWorkflowOutputDelegate {
 
     @Override
-    public void execute(DelegateExecution execution) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name) throws Exception {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -17,7 +18,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -41,7 +41,7 @@ class AbstractWorkflowOutputDelegateTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/AbstractWorkflowOutputDelegateTest.java
@@ -99,7 +99,7 @@ class AbstractWorkflowOutputDelegateTest {
   private static class Impl extends AbstractWorkflowOutputDelegate {
 
     @Override
-    protected void performExecute(DelegateExecution execution, String name) throws Exception {
+    protected void performExecute(DelegateExecution execution, String name, String id) {
       // This is a test and should not do anything.
     }
 

--- a/src/test/java/org/folio/rest/camunda/delegate/CompressFileDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/CompressFileDelegateTest.java
@@ -2,6 +2,7 @@ package org.folio.rest.camunda.delegate;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
 import static org.springframework.test.util.ReflectionTestUtils.setField;
@@ -87,7 +88,7 @@ class CompressFileDelegateTest {
     setField(compressFileDelegate, "inputVariables", null);
     setField(compressFileDelegate, "source", expression);
 
-    try (MockedStatic<FileUtility> fileUtility = Mockito.mockStatic(FileUtility.class)) {
+    try (MockedStatic<FileUtility> fileUtility = mockStatic(FileUtility.class)) {
 
       File sourceFile = Mockito.mock(File.class);
       File destinationFile = Mockito.mock(File.class);

--- a/src/test/java/org/folio/rest/camunda/delegate/CompressFileDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/CompressFileDelegateTest.java
@@ -1,7 +1,13 @@
 package org.folio.rest.camunda.delegate;
 
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.util.ReflectionTestUtils.getField;
@@ -12,6 +18,11 @@ import java.io.BufferedOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
 import org.apache.commons.compress.compressors.CompressorOutputStream;
 import org.folio.rest.camunda.utility.FileUtility;
 import org.folio.rest.workflow.enums.CompressFileContainer;
@@ -21,7 +32,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
@@ -90,16 +100,18 @@ class CompressFileDelegateTest {
 
     try (MockedStatic<FileUtility> fileUtility = mockStatic(FileUtility.class)) {
 
-      File sourceFile = Mockito.mock(File.class);
-      File destinationFile = Mockito.mock(File.class);
-      FileInputStream fileInputStream = Mockito.mock(FileInputStream.class);
-      BufferedInputStream bufferedInputStream = Mockito.mock(BufferedInputStream.class);
-      FileOutputStream fileOutputStream = Mockito.mock(FileOutputStream.class);
-      BufferedOutputStream bufferedOutputStream = Mockito.mock(BufferedOutputStream.class);
-      CompressorOutputStream<?> compressorOutputStream = Mockito.mock(CompressorOutputStream.class);
+      File sourceFile = mock(File.class);
+      File destinationFile = mock(File.class);
+
+      FileInputStream fileInputStream = mock(FileInputStream.class);
+      BufferedInputStream bufferedInputStream = mock(BufferedInputStream.class);
+      FileOutputStream fileOutputStream = mock(FileOutputStream.class);
+      BufferedOutputStream bufferedOutputStream = mock(BufferedOutputStream.class);
+      CompressorOutputStream<?> compressorOutputStream = mock(CompressorOutputStream.class);
 
       when(delegateExecution.getBpmnModelElementInstance()).thenReturn(flowElement);
-      when(flowElement.getName()).thenReturn("determineStartTime");
+      when(flowElement.getName()).thenReturn("delegateName");
+      when(flowElement.getId()).thenReturn("delegateId");
 
       when(expression.getValue(delegateExecution))
         .thenReturn((Object) "sourcePathTemplate")
@@ -123,6 +135,99 @@ class CompressFileDelegateTest {
       fileUtility.when(() -> FileUtility.createBufferedOutputStream(any())).thenReturn(bufferedOutputStream);
       fileUtility.when(() -> FileUtility.createCompressorOutputStream(any(), any())).thenReturn(compressorOutputStream);
       // FileUtility.iOUtilsCopyAndClose() does not need to be mocked with a doNothing() for static mocks.
+
+      compressFileDelegate.execute(delegateExecution);
+
+      fileUtility.verify(() -> FileUtility.iOUtilsCopyAndClose(any(), any()));
+    }
+  }
+
+  @Test
+  void testExecuteBzipWithContainerWorks() throws Exception {
+    setField(compressFileDelegate, "format", expression);
+    setField(compressFileDelegate, "container", expression);
+    setField(compressFileDelegate, "destination", expression);
+    setField(compressFileDelegate, "inputVariables", null);
+    setField(compressFileDelegate, "source", expression);
+
+    try (
+      MockedStatic<FileUtility> fileUtility = mockStatic(FileUtility.class);
+      MockedStatic<Path> pathUtility = mockStatic(Path.class);
+    ) {
+
+      File destinationFile = mock(File.class);
+      File directoryFile = mock(File.class);
+      File regularFile = mock(File.class);
+      File sourceFile = mock(File.class);
+      File tarFile = mock(File.class);
+
+      FileTime fileTime = mock(FileTime.class);
+
+      Path filePath = mock(Path.class);
+
+      FileInputStream fileInputStream = mock(FileInputStream.class);
+      BufferedInputStream bufferedInputStream = mock(BufferedInputStream.class);
+      FileOutputStream fileOutputStream = mock(FileOutputStream.class);
+      BufferedOutputStream bufferedOutputStream = mock(BufferedOutputStream.class);
+      CompressorOutputStream<?> compressorOutputStream = mock(CompressorOutputStream.class);
+      TarArchiveEntry tarArchiveEntry = mock(TarArchiveEntry.class);
+      TarArchiveOutputStream tarArchiveOutputStream = mock(TarArchiveOutputStream.class);
+
+      when(delegateExecution.getBpmnModelElementInstance()).thenReturn(flowElement);
+      when(flowElement.getName()).thenReturn("delegateName");
+      when(flowElement.getId()).thenReturn("delegateId");
+
+      when(expression.getValue(delegateExecution))
+        .thenReturn((Object) "sourcePathTemplate")
+        .thenReturn((Object) "destinationPathTemplate")
+        .thenReturn((Object) CompressFileFormat.GZIP)
+        .thenReturn((Object) CompressFileContainer.TAR);
+
+      fileUtility.when(() -> FileUtility.createFile(any()))
+        .thenReturn(sourceFile)
+        .thenReturn(destinationFile)
+        .thenReturn(destinationFile)
+        .thenReturn(tarFile)
+        .thenReturn(directoryFile)
+        .thenReturn(regularFile);
+
+      when(destinationFile.isDirectory()).thenReturn(true);
+      when(sourceFile.exists()).thenReturn(true);
+      when(sourceFile.canRead()).thenReturn(true);
+
+      when(tarFile.isDirectory())
+        .thenReturn(true)
+        .thenReturn(false);
+
+      final File[] tarDirectoryFiles = { directoryFile };
+
+      when(fileTime.toMillis()).thenReturn(1L);
+
+      when(tarFile.listFiles()).thenReturn(tarDirectoryFiles);
+      when(tarFile.getName()).thenReturn(VALUE);
+
+      when(directoryFile.getAbsolutePath()).thenReturn(VALUE);
+
+      doNothing().when(tarArchiveEntry).setModTime(anyLong());
+
+      doNothing().when(tarArchiveOutputStream).closeArchiveEntry();
+      doNothing().when(tarArchiveOutputStream).putArchiveEntry(any());
+      doNothing().when(tarArchiveOutputStream).finish();
+
+      fileUtility.when(() -> FileUtility.createFileInputStream(any())).thenReturn(fileInputStream);
+      fileUtility.when(() -> FileUtility.createBufferedInputStream(any())).thenReturn(bufferedInputStream);
+      fileUtility.when(() -> FileUtility.createFileOutputStream(any())).thenReturn(fileOutputStream);
+      fileUtility.when(() -> FileUtility.createBufferedOutputStream(any())).thenReturn(bufferedOutputStream);
+      fileUtility.when(() -> FileUtility.createCompressorOutputStream(any(), any())).thenReturn(compressorOutputStream);
+      fileUtility.when(() -> FileUtility.createTarArchiveEntry(any(), anyString())).thenReturn(tarArchiveEntry);
+      fileUtility.when(() -> FileUtility.createTarArchiveOutputStream(any(), anyInt(), anyString())).thenReturn(tarArchiveOutputStream);
+      fileUtility.when(() -> FileUtility.filesSize(any())).thenReturn(1L);
+      fileUtility.when(() -> FileUtility.filesGetLastModifiedTime(any())).thenReturn(fileTime);
+      // FileUtility.iOUtilsCopyAndClose() does not need to be mocked with a doNothing() for static mocks.
+
+      pathUtility.when(() -> Path.of(any(URI.class))).thenReturn(filePath);
+
+      fileUtility.when(() -> FileUtility.filesSize(any())).thenReturn(1L);
 
       compressFileDelegate.execute(delegateExecution);
 

--- a/src/test/java/org/folio/rest/camunda/delegate/FileDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/FileDelegateTest.java
@@ -1,6 +1,7 @@
 package org.folio.rest.camunda.delegate;
 
 import static org.folio.rest.camunda.utility.TestUtility.i;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -23,7 +24,9 @@ import org.apache.commons.lang.StringUtils;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.folio.rest.workflow.enums.FileOp;
 import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.folio.rest.workflow.model.FileTask;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -103,6 +106,11 @@ class FileDelegateTest {
     delegate.setLine(line);
     delegate.setOp(op);
     delegate.setTarget(target);
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(FileTask.class, delegate.fromTask());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/camunda/delegate/FtpDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/FtpDelegateTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.camunda.delegate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
@@ -19,7 +20,9 @@ import org.apache.commons.vfs2.FileSystemManager;
 import org.apache.commons.vfs2.Selectors;
 import org.apache.commons.vfs2.VFS;
 import org.folio.rest.camunda.service.ScriptEngineService;
+import org.folio.rest.workflow.model.FtpTask;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -105,6 +108,11 @@ class FtpDelegateTest {
     delegate.setPort(port);
     delegate.setUsername(username);
     delegate.setPassword(password);
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(FtpTask.class, delegate.fromTask());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/camunda/delegate/FtpDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/FtpDelegateTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -26,7 +27,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.RuntimeService;
@@ -139,7 +139,7 @@ class FtpDelegateTest {
     lenient().when(username.getValue(any(DelegateExecution.class))).thenReturn(usernameValue);
     lenient().when(password.getValue(any(DelegateExecution.class))).thenReturn(passwordValue);
 
-    try (MockedStatic<VFS> utility = Mockito.mockStatic(VFS.class)) {
+    try (MockedStatic<VFS> utility = mockStatic(VFS.class)) {
 
       FileSystemManager manager = mock(FileSystemManager.class);
 

--- a/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
@@ -97,11 +97,10 @@ class ProcessorDelegateTest {
     if (Objects.nonNull(exception)) {
       assertThrows(exception, () -> delegate.execute(execution));
     } else {
-
       delegate.execute(execution);
 
-      verify(execution, times(2)).getBpmnModelElementInstance();
-      verify(element, times(2)).getName();
+      verify(execution, times(1)).getBpmnModelElementInstance();
+      verify(element, times(1)).getName();
       verify(processor, times(1)).getValue(any(DelegateExecution.class));
       verify(mapper, times(1)).readValue(processorValue, EmbeddedProcessor.class);
       verify(mapper, times(1)).readValue(eq(inputVariablesValue), any(TypeReference.class));

--- a/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.camunda.delegate;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -16,8 +17,10 @@ import org.folio.rest.workflow.enums.ScriptType;
 import org.folio.rest.workflow.enums.VariableType;
 import org.folio.rest.workflow.model.EmbeddedProcessor;
 import org.folio.rest.workflow.model.EmbeddedVariable;
+import org.folio.rest.workflow.model.ProcessorTask;
 import org.folio.spring.test.helper.MapperHelper;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -78,6 +81,11 @@ class ProcessorDelegateTest {
 
     // unique per delegate
     delegate.setProcessor(processor);
+  }
+
+  @Test
+  void testFromTaskWorks() {
+    assertEquals(ProcessorTask.class, delegate.fromTask());
   }
 
   @ParameterizedTest

--- a/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/ProcessorDelegateTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Objects;
 import java.util.stream.Stream;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.folio.rest.workflow.enums.ScriptType;
 import org.folio.rest.workflow.enums.VariableType;
@@ -33,7 +34,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
-import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(SpringExtension.class)
@@ -158,8 +158,8 @@ class ProcessorDelegateTest {
     String process = om.writeValueAsString(p);
 
     return Stream.of(
-        Arguments.of(null, null, null, NullPointerException.class),
-        Arguments.of("", "", "", MismatchedInputException.class),
+        Arguments.of(null, null, null, DelegateExecutionFailure.class),
+        Arguments.of("", "", "", DelegateExecutionFailure.class),
         Arguments.of(EMPTY_OBJECT, "[]", EMPTY_OBJECT, null),
         Arguments.of(jsTestString, "[]", local, null),
         Arguments.of(groovyTestString, "[]", process, null));

--- a/src/test/java/org/folio/rest/camunda/delegate/RequestDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/RequestDelegateTest.java
@@ -109,6 +109,40 @@ class RequestDelegateTest {
   }
 
   @Test
+  void testExecuteWithEmptyBodyTrueWorks() throws Exception {
+
+    setField(request, "bodyTemplate", null);
+    setField(request, "sendEmptyBody", true);
+    requestStr = "{\"url\":\"http://localhost/\",\"method\":\"GET\",\"contentType\":\"application/json\",\"accept\":\"application/json\",\"bodyTemplate\":null,\"sendEmptyBody\":true,\"iterable\":false,\"iterableKey\":null,\"responseKey\":null}";
+
+    setupExecuteMocking(false);
+
+    when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
+
+    requestDelegate.execute(delegateExecution);
+
+    verify(delegateExecution, never()).setVariable(anyString(), any());
+    verify(delegateExecution, never()).setVariableLocal(anyString(), any());
+  }
+
+  @Test
+  void testExecuteWithEmptyBodyFalseWorks() throws Exception {
+
+    setField(request, "bodyTemplate", null);
+    setField(request, "sendEmptyBody", false);
+    requestStr = "{\"url\":\"http://localhost/\",\"method\":\"GET\",\"contentType\":\"application/json\",\"accept\":\"application/json\",\"bodyTemplate\":null,\"sendEmptyBody\":false,\"iterable\":false,\"iterableKey\":null,\"responseKey\":null}";
+
+    setupExecuteMocking(false);
+
+    when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
+
+    requestDelegate.execute(delegateExecution);
+
+    verify(delegateExecution, never()).setVariable(anyString(), any());
+    verify(delegateExecution, never()).setVariableLocal(anyString(), any());
+  }
+
+  @Test
   void testExecuteWorksAsArray() throws Exception {
     embeddedVariable.setType(VariableType.PROCESS);
     embeddedVariable.setAsArray(true);

--- a/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
@@ -80,7 +80,7 @@ class SetupDelegateTest {
 
       delegate.execute(execution);
 
-      verify(element, times(2)).getName();
+      verify(element, times(1)).getName();
       verify(initialContext, times(1)).getValue(any(DelegateExecution.class));
       verify(processors, times(1)).getValue(any(DelegateExecution.class));
       verify(mapper, times(1)).readValue(eq(initialContextValue), any(TypeReference.class));

--- a/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Objects;
 import java.util.stream.Stream;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
 import org.folio.rest.camunda.service.ScriptEngineService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,7 +27,6 @@ import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.model.bpmn.instance.FlowElement;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import tools.jackson.core.type.TypeReference;
-import tools.jackson.databind.exc.MismatchedInputException;
 import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(SpringExtension.class)
@@ -112,14 +112,14 @@ class SetupDelegateTest {
    */
   private static Stream<Arguments> executionStream() {
     return Stream.of(
-      Arguments.of(null, null, NullPointerException.class),
-      Arguments.of(null, "",   NullPointerException.class),
-      Arguments.of(null, "[]", NullPointerException.class),
-      Arguments.of("",   null, MismatchedInputException.class),
-      Arguments.of("",   "",   MismatchedInputException.class),
-      Arguments.of("",   "[]", MismatchedInputException.class),
-      Arguments.of("{}", null, NullPointerException.class),
-      Arguments.of("{}", "",   MismatchedInputException.class),
+      Arguments.of(null, null, DelegateExecutionFailure.class),
+      Arguments.of(null, "",   DelegateExecutionFailure.class),
+      Arguments.of(null, "[]", DelegateExecutionFailure.class),
+      Arguments.of("",   null, DelegateExecutionFailure.class),
+      Arguments.of("",   "",   DelegateExecutionFailure.class),
+      Arguments.of("",   "[]", DelegateExecutionFailure.class),
+      Arguments.of("{}", null, DelegateExecutionFailure.class),
+      Arguments.of("{}", "",   DelegateExecutionFailure.class),
       Arguments.of("{}", "[]", null)
     );
   }

--- a/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/SetupDelegateTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 import java.util.Objects;
 import java.util.stream.Stream;
@@ -21,7 +22,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.delegate.DelegateExecution;
 import org.operaton.bpm.engine.delegate.Expression;
 import org.operaton.bpm.model.bpmn.instance.FlowElement;
@@ -36,12 +36,6 @@ class SetupDelegateTest {
   @Spy
   protected JsonMapper mapper;
 
-  @Spy
-  protected RuntimeService runtimeService;
-
-  @Spy
-  private ScriptEngineService scriptEngineService;
-
   @Mock
   Expression initialContext;
 
@@ -53,6 +47,9 @@ class SetupDelegateTest {
 
   @Mock
   FlowElement element;
+
+  @Mock
+  ScriptEngineService scriptEngineService;
 
   @InjectMocks
   SetupDelegate delegate;
@@ -73,6 +70,10 @@ class SetupDelegateTest {
     lenient().when(element.getName()).thenReturn(delegate.getClass().getSimpleName());
     lenient().when(initialContext.getValue(any(DelegateExecution.class))).thenReturn(initialContextValue);
     lenient().when(processors.getValue(any(DelegateExecution.class))).thenReturn(processorsValue);
+
+    setField(delegate, "scriptEngineService", scriptEngineService);
+
+    lenient().doNothing().when(scriptEngineService).registerScript(anyString(), anyString(), anyString());
 
     if (Objects.nonNull(exception)) {
       assertThrows(exception, () -> delegate.execute(execution));
@@ -111,6 +112,11 @@ class SetupDelegateTest {
    *     - exception that is expected to be thrown for inputs
    */
   private static Stream<Arguments> executionStream() {
+
+    final String ctx1 = "{ \"a\": 0 }";
+    final String ctx2 = "{ \"a\": 0, \"b\": \"bee\" }";
+    final String prc1 = "[ { \"id\": \"84d0181e-8e0f-4d80-a580-03fe45b3c179\", \"name\": \"Start\", \"description\": \"Start of Example Javascript ScriptTask Workflow.\", \"type\": \"MESSAGE_CORRELATION\", \"deserializeAs\": \"StartEvent\", \"expression\": \"/events/example-scripttask-js/start\" } ]";
+
     return Stream.of(
       Arguments.of(null, null, DelegateExecutionFailure.class),
       Arguments.of(null, "",   DelegateExecutionFailure.class),
@@ -120,7 +126,10 @@ class SetupDelegateTest {
       Arguments.of("",   "[]", DelegateExecutionFailure.class),
       Arguments.of("{}", null, DelegateExecutionFailure.class),
       Arguments.of("{}", "",   DelegateExecutionFailure.class),
-      Arguments.of("{}", "[]", null)
+      Arguments.of("{}", "[]", null),
+      Arguments.of(ctx1, "[]", null),
+      Arguments.of(ctx2, "[]", null),
+      Arguments.of("{}", prc1, null)
     );
   }
 

--- a/src/test/java/org/folio/rest/camunda/exception/DelegateExecutionFailureTest.java
+++ b/src/test/java/org/folio/rest/camunda/exception/DelegateExecutionFailureTest.java
@@ -1,0 +1,42 @@
+package org.folio.rest.camunda.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.ID;
+import static org.folio.spring.test.mock.MockMvcConstant.UUID;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DelegateExecutionFailureTest {
+
+  private static final Exception EXCEPTION = new RuntimeException();
+
+  @Test
+  void delegateExecutionFailureWorksTest() {
+    DelegateExecutionFailure exception = Assertions.assertThrows(DelegateExecutionFailure.class, () -> {
+      throw new DelegateExecutionFailure(VALUE, UUID, ID);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(VALUE));
+    assertTrue(exception.getMessage().contains(UUID));
+    assertTrue(exception.getMessage().contains(ID));
+  }
+
+  @Test
+  void delegateExecutionFailureWorksWithParameterTest() {
+    DelegateExecutionFailure exception = Assertions.assertThrows(DelegateExecutionFailure.class, () -> {
+      throw new DelegateExecutionFailure(VALUE, UUID, ID, EXCEPTION);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(VALUE));
+    assertTrue(exception.getMessage().contains(UUID));
+    assertTrue(exception.getMessage().contains(ID));
+  }
+}

--- a/src/test/java/org/folio/rest/camunda/exception/RequestMissingWorkflowExceptionTest.java
+++ b/src/test/java/org/folio/rest/camunda/exception/RequestMissingWorkflowExceptionTest.java
@@ -1,0 +1,37 @@
+package org.folio.rest.camunda.exception;
+
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RequestMissingWorkflowExceptionTest {
+
+  private static final Exception EXCEPTION = new RuntimeException();
+
+  @Test
+  void workflowAlreadyActiveExceptionWorksTest() {
+    RequestMissingWorkflowException exception = Assertions.assertThrows(RequestMissingWorkflowException.class, () -> {
+      throw new RequestMissingWorkflowException(VALUE);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(VALUE));
+  }
+
+  @Test
+  void workflowAlreadyActiveExceptionWorksWithParameterTest() {
+    RequestMissingWorkflowException exception = Assertions.assertThrows(RequestMissingWorkflowException.class, () -> {
+      throw new RequestMissingWorkflowException(VALUE, EXCEPTION);
+    });
+
+    assertNotNull(exception);
+    assertTrue(exception.getMessage().contains(VALUE));
+  }
+
+}

--- a/src/test/java/org/folio/rest/camunda/kafka/EventConsumerTest.java
+++ b/src/test/java/org/folio/rest/camunda/kafka/EventConsumerTest.java
@@ -4,6 +4,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.util.HashMap;
 import java.util.stream.Stream;
@@ -16,7 +19,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.RuntimeService;
 import org.operaton.bpm.engine.runtime.MessageCorrelationBuilder;
@@ -46,15 +48,15 @@ class EventConsumerTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
-    eventConsumer = Mockito.spy(new EventConsumer(runtimeService, mapper));
+    mapper = spy(MapperHelper.build());
+    eventConsumer = spy(new EventConsumer(runtimeService, mapper));
   }
 
   @ParameterizedTest
   @MethodSource("provideEventStream")
   @SuppressWarnings("unchecked")
   void testReceive(Event event) {
-    try (MockedStatic<ThreadLocalStorage> utility = Mockito.mockStatic(ThreadLocalStorage.class)) {
+    try (MockedStatic<ThreadLocalStorage> utility = mockStatic(ThreadLocalStorage.class)) {
       doReturn(processInstance).when(messageCorrelationBuilder).correlateStartMessage();
       doReturn(messageCorrelationBuilder).when(messageCorrelationBuilder).setVariables(anyMap());
       doReturn(messageCorrelationBuilder).when(messageCorrelationBuilder).tenantId(anyString());
@@ -68,7 +70,7 @@ class EventConsumerTest {
         ThreadLocalStorage.setTenant(event.getTenant());
       });
 
-      Mockito.verify(messageCorrelationBuilder).correlateStartMessage();
+      verify(messageCorrelationBuilder).correlateStartMessage();
     }
   }
 

--- a/src/test/java/org/folio/rest/camunda/service/BpmnModelFactoryTest.java
+++ b/src/test/java/org/folio/rest/camunda/service/BpmnModelFactoryTest.java
@@ -10,6 +10,8 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -111,7 +113,7 @@ class BpmnModelFactoryTest {
 
   @BeforeEach
   void beforeEach() {
-    mapper = Mockito.spy(MapperHelper.build());
+    mapper = spy(MapperHelper.build());
 
     bpmnModelFactory = new BpmnModelFactory(mapper, workflowDelegates);
 
@@ -144,7 +146,7 @@ class BpmnModelFactoryTest {
 
   @Test
   void testFromWorkflowExceptionDuringSetupUsingWarnings() throws ScriptTaskDeserializeCodeFailure, JacksonException {
-    try (MockedStatic<Bpmn> utility = Mockito.mockStatic(Bpmn.class)) {
+    try (MockedStatic<Bpmn> utility = mockStatic(Bpmn.class)) {
       commonUnmockedProcessBuilder(utility);
       commonMockingsBasic();
 
@@ -159,7 +161,7 @@ class BpmnModelFactoryTest {
 
   @Test
   void testFromWorkflowNoNodesWorks() throws ScriptTaskDeserializeCodeFailure {
-    try (MockedStatic<Bpmn> utility = Mockito.mockStatic(Bpmn.class)) {
+    try (MockedStatic<Bpmn> utility = mockStatic(Bpmn.class)) {
       commonUnmockedProcessBuilder(utility);
       commonMockingsBasic();
 
@@ -172,7 +174,7 @@ class BpmnModelFactoryTest {
     nodes.add(simpleNode);
     workflow.setNodes(nodes);
 
-    try (MockedStatic<Bpmn> utility = Mockito.mockStatic(Bpmn.class)) {
+    try (MockedStatic<Bpmn> utility = mockStatic(Bpmn.class)) {
       commonMockedProcessBuilder(utility);
 
       when(processBuilderMocked.startEvent()).thenReturn(startEventBuilder);
@@ -193,7 +195,7 @@ class BpmnModelFactoryTest {
     nodes.add(endNode);
     workflow.setNodes(nodes);
 
-    try (MockedStatic<Bpmn> utility = Mockito.mockStatic(Bpmn.class)) {
+    try (MockedStatic<Bpmn> utility = mockStatic(Bpmn.class)) {
       commonMockedProcessBuilder(utility);
       commonMockingsBasic();
 

--- a/src/test/java/org/folio/rest/camunda/service/CamundaApiServiceTest.java
+++ b/src/test/java/org/folio/rest/camunda/service/CamundaApiServiceTest.java
@@ -12,14 +12,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import org.operaton.bpm.engine.exception.NotValidException;
-import org.operaton.bpm.engine.ProcessEngine;
-import org.operaton.bpm.engine.ProcessEngines;
-import org.operaton.bpm.engine.RepositoryService;
-import org.operaton.bpm.engine.repository.Deployment;
-import org.operaton.bpm.engine.repository.DeploymentBuilder;
-import org.operaton.bpm.model.bpmn.Bpmn;
-import org.operaton.bpm.model.bpmn.BpmnModelInstance;
+import org.folio.rest.camunda.exception.RequestMissingWorkflowException;
 import org.folio.rest.camunda.exception.ScriptTaskDeserializeCodeFailure;
 import org.folio.rest.camunda.exception.WorkflowAlreadyActiveException;
 import org.folio.rest.workflow.model.Workflow;
@@ -31,6 +24,14 @@ import org.mockito.Mock;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.operaton.bpm.engine.ProcessEngine;
+import org.operaton.bpm.engine.ProcessEngines;
+import org.operaton.bpm.engine.RepositoryService;
+import org.operaton.bpm.engine.exception.NotValidException;
+import org.operaton.bpm.engine.repository.Deployment;
+import org.operaton.bpm.engine.repository.DeploymentBuilder;
+import org.operaton.bpm.model.bpmn.Bpmn;
+import org.operaton.bpm.model.bpmn.BpmnModelInstance;
 
 @ExtendWith(MockitoExtension.class)
 class CamundaApiServiceTest {
@@ -111,6 +112,16 @@ class CamundaApiServiceTest {
 
       assertThrows(NotValidException.class, () -> camundaApiService.deployWorkflow(workflow, TENANT));
     }
+  }
+
+  @Test
+  void testDeployWorkflowMissingWOrkflowException() {
+    assertThrows(RequestMissingWorkflowException.class, () -> camundaApiService.deployWorkflow(null, TENANT));
+  }
+
+  @Test
+  void testUndeployWorkflowMissingWOrkflowException() {
+    assertThrows(RequestMissingWorkflowException.class, () -> camundaApiService.undeployWorkflow(null));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/camunda/service/CamundaApiServiceTest.java
+++ b/src/test/java/org/folio/rest/camunda/service/CamundaApiServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -22,7 +23,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.operaton.bpm.engine.ProcessEngine;
 import org.operaton.bpm.engine.ProcessEngines;
@@ -82,8 +82,8 @@ class CamundaApiServiceTest {
   @Test
   void testDeployWorkflow() throws ScriptTaskDeserializeCodeFailure, WorkflowAlreadyActiveException {
     try (
-        MockedStatic<ProcessEngines> utilityProcessEngines = Mockito.mockStatic(ProcessEngines.class);
-        MockedStatic<Bpmn> utilityBpmn = Mockito.mockStatic(Bpmn.class);
+        MockedStatic<ProcessEngines> utilityProcessEngines = mockStatic(ProcessEngines.class);
+        MockedStatic<Bpmn> utilityBpmn = mockStatic(Bpmn.class);
       ) {
       utilityProcessEngines.when(ProcessEngines::getDefaultProcessEngine).thenReturn(processEngine);
       utilityBpmn.when(() -> Bpmn.validateModel(modelInstance)).thenAnswer(answer -> null);
@@ -102,8 +102,8 @@ class CamundaApiServiceTest {
   @Test
   void testDeployWorkflowException() {
     try (
-        MockedStatic<ProcessEngines> utilityProcessEngines = Mockito.mockStatic(ProcessEngines.class);
-        MockedStatic<Bpmn> utilityBpmn = Mockito.mockStatic(Bpmn.class);
+        MockedStatic<ProcessEngines> utilityProcessEngines = mockStatic(ProcessEngines.class);
+        MockedStatic<Bpmn> utilityBpmn = mockStatic(Bpmn.class);
     ) {
       utilityProcessEngines.when(ProcessEngines::getDefaultProcessEngine).thenReturn(processEngine);
       utilityBpmn.when(() -> Bpmn.validateModel(modelInstance)).thenAnswer(answer -> null);
@@ -135,7 +135,7 @@ class CamundaApiServiceTest {
   void testUndeployWorkflow() throws ScriptTaskDeserializeCodeFailure, WorkflowAlreadyActiveException {
     testDeployWorkflow();
 
-    try (MockedStatic<ProcessEngines> utilityProcessEngines = Mockito.mockStatic(ProcessEngines.class)) {
+    try (MockedStatic<ProcessEngines> utilityProcessEngines = mockStatic(ProcessEngines.class)) {
       utilityProcessEngines.when(ProcessEngines::getDefaultProcessEngine).thenReturn(processEngine);
 
       Workflow result = camundaApiService.undeployWorkflow(workflow);
@@ -150,7 +150,7 @@ class CamundaApiServiceTest {
 
   @Test
   void testUndeployWorkflowNotActive() {
-    try (MockedStatic<ProcessEngines> utilityProcessEngines = Mockito.mockStatic(ProcessEngines.class)) {
+    try (MockedStatic<ProcessEngines> utilityProcessEngines = mockStatic(ProcessEngines.class)) {
       utilityProcessEngines.when(ProcessEngines::getDefaultProcessEngine).thenReturn(processEngine);
 
       Workflow result = camundaApiService.undeployWorkflow(workflow);

--- a/src/test/java/org/folio/rest/camunda/utility/FileUtilityTest.java
+++ b/src/test/java/org/folio/rest/camunda/utility/FileUtilityTest.java
@@ -1,0 +1,226 @@
+package org.folio.rest.camunda.utility;
+
+import static org.folio.spring.test.mock.MockMvcConstant.INT_VALUE;
+import static org.folio.spring.test.mock.MockMvcConstant.LONG_VALUE;
+import static org.folio.spring.test.mock.MockMvcConstant.VALUE;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.LinkOption;
+import java.nio.file.Path;
+import java.util.zip.ZipOutputStream;
+import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
+import org.apache.commons.compress.archivers.tar.TarArchiveOutputStream;
+import org.apache.commons.compress.compressors.CompressorException;
+import org.apache.commons.compress.compressors.CompressorOutputStream;
+import org.apache.commons.compress.compressors.CompressorStreamFactory;
+import org.apache.commons.io.FileUtils;
+import org.h2.util.IOUtils;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FileUtilityTest {
+
+  @Test
+  void createBufferedInputStreamTest() {
+
+    try (MockedConstruction<BufferedInputStream> construct = mockConstruction(BufferedInputStream.class)) {
+
+      final InputStream arg1 = mock(InputStream.class);
+
+      assertNotNull(FileUtility.createBufferedInputStream(arg1));
+    }
+  }
+
+  @Test
+  void createFileOutputStreamTest() throws FileNotFoundException {
+
+    try (MockedConstruction<FileOutputStream> construct = mockConstruction(FileOutputStream.class)) {
+
+      final File arg1 = mock(File.class);
+
+      assertNotNull(FileUtility.createFileOutputStream(arg1));
+    }
+  }
+
+  @Test
+  void createCompressorOutputStreamTest() throws CompressorException {
+
+    final CompressorOutputStream<?> stream = mock(CompressorOutputStream.class);
+
+    try (MockedConstruction<CompressorStreamFactory> construct = mockConstruction(
+      CompressorStreamFactory.class,
+      (mock, context) -> {
+        when(mock.createCompressorOutputStream(anyString(), any(OutputStream.class))).thenAnswer(invocation -> {
+          return stream;
+        });
+      }
+    )) {
+
+      final OutputStream arg1 = mock(OutputStream.class);
+
+      assertNotNull(FileUtility.createCompressorOutputStream(VALUE, arg1));
+    }
+  }
+
+  @Test
+  void createBufferedOutputStreamTest() {
+
+    try (MockedConstruction<FileOutputStream> construct = mockConstruction(FileOutputStream.class)) {
+
+      final OutputStream arg1 = mock(OutputStream.class);
+
+      assertNotNull(FileUtility.createBufferedOutputStream(arg1));
+    }
+  }
+
+  @Test
+  void createFileTest() {
+
+    try (MockedConstruction<File> construct = mockConstruction(File.class)) {
+
+      assertNotNull(FileUtility.createFile(VALUE));
+    }
+  }
+
+  @Test
+  void createFileInputStreamTest() throws FileNotFoundException {
+
+    try (MockedConstruction<FileInputStream> construct = mockConstruction(FileInputStream.class)) {
+
+      final File arg1 = mock(File.class);
+
+      assertNotNull(FileUtility.createFileInputStream(arg1));
+    }
+  }
+
+  @Test
+  void createTarArchiveEntryTest() {
+
+    try (MockedConstruction<TarArchiveEntry> construct = mockConstruction(TarArchiveEntry.class)) {
+
+      final File arg1 = mock(File.class);
+
+      assertNotNull(FileUtility.createTarArchiveEntry(arg1, VALUE));
+    }
+  }
+
+  @Test
+  void createTarArchiveOutputStreamTest() {
+
+    try (MockedConstruction<TarArchiveOutputStream> construct = mockConstruction(TarArchiveOutputStream.class)) {
+
+      final OutputStream arg1 = mock(OutputStream.class);
+
+      assertNotNull(FileUtility.createTarArchiveOutputStream(arg1, INT_VALUE, VALUE));
+    }
+  }
+
+  @Test
+  void createZipOutputStreamTest() {
+
+    try (MockedConstruction<ZipOutputStream> construct = mockConstruction(ZipOutputStream.class)) {
+
+      final OutputStream arg1 = mock(OutputStream.class);
+
+      assertNotNull(FileUtility.createZipOutputStream(arg1));
+    }
+  }
+
+  @Test
+  void fileUtilsCopyFileTest() throws IOException {
+
+    try (MockedStatic<FileUtils> utility = mockStatic(FileUtils.class)) {
+
+      final File arg1 = mock(File.class);
+      final File arg2 = mock(File.class);
+
+      FileUtility.fileUtilsCopyFile(arg1, arg2);
+
+      utility.verify(() -> FileUtils.copyFile(arg1, arg2));
+    }
+  }
+
+  @Test
+  void filesCopyTest() throws IOException {
+
+    try (MockedStatic<Files> utility = mockStatic(Files.class)) {
+
+      final Path arg1 = mock(Path.class);
+      final OutputStream arg2 = mock(OutputStream.class);
+
+      FileUtility.filesCopy(arg1, arg2);
+
+      utility.verify(() -> Files.copy(arg1, arg2));
+    }
+  }
+
+  @Test
+  void filesGetLastModifiedTimeTest() throws IOException {
+
+    try (MockedStatic<Files> utility = mockStatic(Files.class)) {
+
+      final Path arg1 = mock(Path.class);
+      final LinkOption arg2 = mock(LinkOption.class);
+
+      FileUtility.filesGetLastModifiedTime(arg1, arg2);
+
+      utility.verify(() -> Files.getLastModifiedTime(arg1, arg2));
+    }
+  }
+
+  @Test
+  void filesSizeTest() throws IOException {
+
+    try (MockedStatic<Files> utility = mockStatic(Files.class)) {
+
+      final Path arg1 = mock(Path.class);
+
+      utility.when(() -> Files.size(any())).thenReturn(LONG_VALUE);
+
+      final long result = FileUtility.filesSize(arg1);
+
+      utility.verify(() -> Files.size(arg1));
+
+      assertEquals(LONG_VALUE, result);
+    }
+  }
+
+  @Test
+  void iOUtilsCopyAndCloseTest() throws IOException {
+
+    try (MockedStatic<IOUtils> utility = mockStatic(IOUtils.class)) {
+
+      final InputStream arg1 = mock(InputStream.class);
+      final OutputStream arg2 = mock(OutputStream.class);
+
+      utility.when(() -> IOUtils.copyAndClose(any(), any())).thenReturn(LONG_VALUE);
+
+      final long result = FileUtility.iOUtilsCopyAndClose(arg1, arg2);
+
+      utility.verify(() -> IOUtils.copyAndClose(arg1, arg2));
+
+      assertEquals(LONG_VALUE, result);
+    }
+  }
+
+}

--- a/src/test/java/org/folio/rest/camunda/utility/LoggerStreamTest.java
+++ b/src/test/java/org/folio/rest/camunda/utility/LoggerStreamTest.java
@@ -1,0 +1,88 @@
+package org.folio.rest.camunda.utility;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.slf4j.event.Level;
+import org.slf4j.spi.LoggingEventBuilder;
+
+@ExtendWith(MockitoExtension.class)
+class LoggerStreamTest {
+
+  private static final String LINE_1 = "1";
+  private static final String LINE_2 = "2";
+  private static final String LINE_3 = "3";
+  private static final String LINES = LINE_1 + "\n" + LINE_2 + "\n" + LINE_3;
+
+  @Mock
+  private Logger logger;
+
+  @Mock
+  private LoggingEventBuilder builder;
+
+  @Captor
+  private ArgumentCaptor<String> printed;
+
+  @Captor
+  private ArgumentCaptor<Level> level;
+
+  private LoggerStream stream;
+
+  @BeforeEach
+  void beforeEach() {
+
+    when(logger.atLevel(Level.INFO)).thenReturn(builder);
+  }
+
+  @Test
+  void loggingWorksWithDataTest() throws IOException {
+
+    try (MockedStatic<LoggerFactory> factory = mockStatic(LoggerFactory.class)) {
+
+      factory.when(() -> LoggerFactory.getLogger(any(Class.class)))
+        .thenReturn(logger);
+
+      stream = new LoggerStream(logger, Level.INFO);
+
+      stream.write(LINES.getBytes());
+      stream.flush();
+
+      verify(logger).atLevel(any());
+      verify(builder).log(LINES);
+    }
+  }
+
+  @Test
+  void loggingWorksWithoutDataTest() {
+
+    try (MockedStatic<LoggerFactory> factory = mockStatic(LoggerFactory.class)) {
+
+      factory.when(() -> LoggerFactory.getLogger(any(Class.class)))
+        .thenReturn(logger);
+
+      stream = new LoggerStream(logger, Level.INFO);
+
+      stream.flush();
+
+      verify(logger).atLevel(any());
+      verify(builder, never()).log(anyString());
+    }
+  }
+
+}
+


### PR DESCRIPTION
Resolves [MODCAMUNDA-66](https://folio-org.atlassian.net/browse/MODCAMUNDA-66) .

Utilize the `sendEmptyBody` property.
Ensure that the `body` is properly sent.
When the `sendEmptyBody` is FALSE and the body is NULL or an empty string, then do not send the body variable to the request function. Make this logic aware of the **HTTP** methods.

Do not attempt to use freemarker on the `bodyTemplate` when it is NULL. Add logging for the `sendEmptyBody` property.
Conditionally send body based on the various conditions.

Making these changes resulted in changing code blocks that are considered overly complex by **SonarQube**. This is resolved by making more major structural changes across the project.

Break apart the request delegate execution into multiple functions.

Use `Boolean.TRUE` checks instead of literal boolean checks (as per **SonarQube**).

The `AbstractDelegate` must call the `execute()` function. Fix the logger to provide accurate information so that the `sendEmptyBody` changes can be more properly observed via system logs.

Add log designating the deployment of the **BPMN** model with additional details.

Restructure the code to reduce the nested and code complexity. The `execute()` function is no longer directly overridden. Instead, a new protected method called `performExecute()` is used to perform this task. This better allows for the logging to operate even on failure. The failure still produces a log and the log output clearly marks it as such. Existing code that needs to handle this differently is updated to override this protected method. The end result is fewer calls to some methods.

The `CamundaApiService` should not use `@Autowired` on the variable and should instead use it on the initializer.

Fix code quality issue where the system logger is being used. This requires making a new class, called `LoggerStream`, that can then be passed to **Camunda**.

Some of the existing tests are not ideal (such as `RequestDelegateTest`). Avoid changing that test design at this time and just repeat the approach.