### PR TITLE
MODCAMUNDA-68: Implement FolioRequestDelagate based off of RequestDelegate.

### DIFF
--- a/src/main/java/org/folio/rest/camunda/delegate/FolioRequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/FolioRequestDelegate.java
@@ -1,0 +1,108 @@
+package org.folio.rest.camunda.delegate;
+
+import freemarker.cache.StringTemplateLoader;
+import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import java.io.IOException;
+import java.util.Map;
+import org.folio.rest.camunda.exception.DelegateExecutionFailure;
+import org.folio.rest.workflow.dto.Request;
+import org.folio.rest.workflow.model.FolioRequestTask;
+import org.folio.spring.web.service.HttpService;
+import org.operaton.bpm.engine.delegate.DelegateExecution;
+import org.springframework.context.annotation.Scope;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+/**
+ * A delegate for performing already logged in FOLIO HTTP requests.
+ *
+ * For logging into FOLIO, use the RequestDelegate instead.
+ */
+@Service
+@Scope("prototype")
+public class FolioRequestDelegate extends RequestDelegate {
+
+  public FolioRequestDelegate(HttpService httpService) {
+    super(httpService);
+  }
+
+  @Override
+  public Class<?> fromTask() {
+    return FolioRequestTask.class;
+  }
+
+  /**
+   * Perform the execution.
+   *
+   * @param execution The execution data.
+   * @param name      The delegate name.
+   * @param id        The delegate ID.
+   */
+  @Override
+  protected void performExecute(DelegateExecution execution, String name, String id) {
+
+    final Map<String, Object> inputs = getInputs(execution);
+    final Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
+
+    final Request requestValue = mapper.readValue(this.request.getValue(execution).toString(), Request.class);
+    final Boolean sendEmptyBody = requestValue.getSendEmptyBody();
+
+    final StringTemplateLoader loader = new StringTemplateLoader();
+    cfg.setTemplateLoader(loader);
+
+    final String body;
+    final String url;
+
+    try {
+      body = performExecuteBuildBody(requestValue.getBodyTemplate(), loader, cfg, inputs);
+      url = performExecuteBuildUrl(requestValue.getUrl(), loader, cfg, inputs);
+    } catch (IOException | TemplateException e) {
+      throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
+
+    if (url == null) {
+      throw new DelegateExecutionFailure(name, id, "No URL specified.");
+    }
+
+    final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
+    final String accept = requestValue.getAccept();
+    final String contentType = requestValue.getContentType();
+
+    final String tenant = execution.getTenantId();
+    final Object token = execution.getVariable("X-Okapi-Token");
+
+    getLogger().info("url: {}", url);
+    getLogger().debug("method: {}", method);
+    getLogger().debug("sendEmptyBody: {}", sendEmptyBody);
+
+    getLogger().debug("accept: {}", accept);
+    getLogger().debug("content-type: {}", contentType);
+    getLogger().debug("tenant: {}", tenant);
+
+    final HttpHeaders headers = new HttpHeaders();
+    headers.add("Accept", accept);
+    headers.add("Content-Type", contentType);
+    headers.add("X-Okapi-Tenant", tenant);
+    headers.add("X-Okapi-Url", okapiUrl);
+
+    if (token != null) {
+      headers.add("X-Okapi-Token", token.toString());
+    }
+
+    final HttpEntity<Object> entity = shouldSendBody(body, sendEmptyBody, method)
+      ? new HttpEntity<>(body, headers)
+      : new HttpEntity<>(headers);
+
+    final ResponseEntity<Object> response = httpService.exchange(url, method, entity, Object.class);
+
+    setOutput(execution, response.getBody());
+
+    getHeaderOutputVariables(execution)
+      .forEach(headerOutputVariable -> performExecuteHeaderOutputVariables(execution, headerOutputVariable, response));
+  }
+
+}

--- a/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
+++ b/src/main/java/org/folio/rest/camunda/delegate/RequestDelegate.java
@@ -8,6 +8,8 @@ import static org.springframework.http.HttpMethod.TRACE;
 
 import freemarker.cache.StringTemplateLoader;
 import freemarker.template.Configuration;
+import freemarker.template.TemplateException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,18 +34,23 @@ import org.springframework.ui.freemarker.FreeMarkerTemplateUtils;
 import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 
+/**
+ * A delegate for performing already logged in FOLIO HTTP requests.
+ *
+ * For FOLIO related requests other than logging, use the FolioRequestDelegate instead.
+ */
 @Service
 @Scope("prototype")
 public class RequestDelegate extends AbstractWorkflowIODelegate {
 
   @Value("${okapi.url}")
-  private String okapiUrl;
+  protected String okapiUrl;
 
-  private HttpService httpService;
+  protected HttpService httpService;
 
-  private Expression request;
+  protected Expression request;
 
-  private Expression headerOutputVariables;
+  protected Expression headerOutputVariables;
 
   public RequestDelegate(HttpService httpService) {
     this.httpService = httpService;
@@ -77,45 +84,32 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
   @Override
   protected void performExecute(DelegateExecution execution, String name, String id) {
 
-    final Request requestValue = mapper.readValue(this.request.getValue(execution).toString(), Request.class);
-
     final Map<String, Object> inputs = getInputs(execution);
     final Configuration cfg = new Configuration(Configuration.VERSION_2_3_23);
 
-    final String bodyTemplate = requestValue.getBodyTemplate();
+    final Request requestValue = mapper.readValue(this.request.getValue(execution).toString(), Request.class);
     final Boolean sendEmptyBody = requestValue.getSendEmptyBody();
 
-    final StringTemplateLoader stringLoader = new StringTemplateLoader();
-    stringLoader.putTemplate("url", requestValue.getUrl());
+    final StringTemplateLoader loader = new StringTemplateLoader();
+    cfg.setTemplateLoader(loader);
 
-    cfg.setTemplateLoader(stringLoader);
-
-    String body = null;
-
-    if (bodyTemplate != null) {
-      stringLoader.putTemplate("body", requestValue.getBodyTemplate());
-
-      try {
-        body = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
-      } catch (Exception e) {
-        throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
-      }
-    }
-
+    final String body;
     final String url;
 
     try {
-      url = FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
-    } catch (Exception e) {
+      body = performExecuteBuildBody(requestValue.getBodyTemplate(), loader, cfg, inputs);
+      url = performExecuteBuildUrl(requestValue.getUrl(), loader, cfg, inputs);
+    } catch (IOException | TemplateException e) {
       throw new DelegateExecutionFailure(name, id, e.getMessage(), e);
+    }
+
+    if (url == null) {
+      throw new DelegateExecutionFailure(name, id, "No URL specified.");
     }
 
     final HttpMethod method = HttpMethod.valueOf(requestValue.getMethod().toString());
     final String accept = requestValue.getAccept();
     final String contentType = requestValue.getContentType();
-
-    final String tenant = execution.getTenantId();
-    final Object token = execution.getVariable("X-Okapi-Token");
 
     getLogger().info("url: {}", url);
     getLogger().debug("method: {}", method);
@@ -123,17 +117,10 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
 
     getLogger().debug("accept: {}", accept);
     getLogger().debug("content-type: {}", contentType);
-    getLogger().debug("tenant: {}", tenant);
 
     final HttpHeaders headers = new HttpHeaders();
     headers.add("Accept", accept);
     headers.add("Content-Type", contentType);
-    headers.add("X-Okapi-Tenant", tenant);
-    headers.add("X-Okapi-Url", okapiUrl);
-
-    if (token != null) {
-      headers.add("X-Okapi-Token", token.toString());
-    }
 
     final HttpEntity<Object> entity = shouldSendBody(body, sendEmptyBody, method)
       ? new HttpEntity<>(body, headers)
@@ -148,12 +135,62 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
   }
 
   /**
+   * Build the body from the body template.
+   *
+   * @param template The body template.
+   * @param loader   The string loader.
+   * @param cfg      The configuration.
+   * @param inputs   The inputs.
+   *
+   * @return The built body or NULL if there is no template.
+   *
+   * @throws IOException       On error.
+   * @throws TemplateException On error.
+   */
+  protected String performExecuteBuildBody(final String template, final StringTemplateLoader loader, final Configuration cfg, final Map<String, Object> inputs)
+      throws IOException, TemplateException {
+
+    if (template == null) {
+      return null;
+    }
+
+    loader.putTemplate("body", template);
+
+    return FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("body"), inputs);
+  }
+
+  /**
+   * Build the body from the URL.
+   *
+   * @param template The URL.
+   * @param loader   The string loader.
+   * @param cfg      The configuration.
+   * @param inputs   The inputs.
+   *
+   * @return The built URL or NULL if there is no URL.
+   *
+   * @throws IOException       On error.
+   * @throws TemplateException On error.
+   */
+  protected String performExecuteBuildUrl(final String url, final StringTemplateLoader loader, final Configuration cfg, final Map<String, Object> inputs)
+      throws IOException, TemplateException {
+
+    if (url == null) {
+      return null;
+    }
+
+    loader.putTemplate("url", url);
+
+    return FreeMarkerTemplateUtils.processTemplateIntoString(cfg.getTemplate("url"), inputs);
+  }
+
+  /**
    * Perform the delegate execution relating to header output variables.
    *
    * @param execution            The delegate execution data.
    * @param headerOutputVariable The embedded variable.
    */
-  private void performExecuteHeaderOutputVariables(
+  protected void performExecuteHeaderOutputVariables(
     final DelegateExecution execution, final EmbeddedVariable headerOutputVariable, final ResponseEntity<Object> response
   ) {
 
@@ -195,7 +232,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    *
    * @return The value, after "spinning".
    */
-  private Object performExecuteHeaderOutputVariablesSpin(final EmbeddedVariable headerOutputVariable, final HttpHeaders headers, final String key) {
+  protected Object performExecuteHeaderOutputVariablesSpin(final EmbeddedVariable headerOutputVariable, final HttpHeaders headers, final String key) {
 
     if (Boolean.TRUE.equals(headerOutputVariable.getAsArray())) {
       final List<String> valueList = new ArrayList<>();
@@ -224,7 +261,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    *
    * @return TRUE on send body and FALSE otherwise.
    */
-  private boolean shouldSendBody(final String body, final Boolean sendEmptyBody, final HttpMethod method) {
+  protected boolean shouldSendBody(final String body, final Boolean sendEmptyBody, final HttpMethod method) {
 
     if (TRACE.equals(method)) return false;
 
@@ -245,7 +282,7 @@ public class RequestDelegate extends AbstractWorkflowIODelegate {
    *
    * @throws DelegateSpinFailure On spin error.
    */
-  private Object spinValue(EmbeddedVariable variable, Object value) throws DelegateSpinFailure {
+  protected Object spinValue(EmbeddedVariable variable, Object value) throws DelegateSpinFailure {
     try {
       return Boolean.TRUE.equals(variable.getSpin()) ? JSON(mapper.writeValueAsString(value)) : value;
     } catch (JacksonException e) {

--- a/src/test/java/org/folio/rest/camunda/delegate/FolioRequestDelegateTest.java
+++ b/src/test/java/org/folio/rest/camunda/delegate/FolioRequestDelegateTest.java
@@ -17,7 +17,7 @@ import java.util.Set;
 import org.folio.rest.workflow.dto.Request;
 import org.folio.rest.workflow.enums.VariableType;
 import org.folio.rest.workflow.model.EmbeddedVariable;
-import org.folio.rest.workflow.model.RequestTask;
+import org.folio.rest.workflow.model.FolioRequestTask;
 import org.folio.spring.test.helper.MapperHelper;
 import org.folio.spring.web.service.HttpService;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,7 +38,7 @@ import tools.jackson.core.JacksonException;
 import tools.jackson.databind.json.JsonMapper;
 
 @ExtendWith(MockitoExtension.class)
-class RequestDelegateTest {
+class FolioRequestDelegateTest {
 
   private static final String TOKEN_HEADER_NAME = "X-Okapi-Token";
 
@@ -58,7 +58,7 @@ class RequestDelegateTest {
   private Expression requestExpression;
 
   @InjectMocks
-  private RequestDelegate delegate;
+  private FolioRequestDelegate delegate;
 
   @Mock
   ResponseEntity<Object> responseEntity;
@@ -215,6 +215,7 @@ class RequestDelegateTest {
   void testExecuteWorksWithToken() throws Exception {
     setupExecuteMocking(false);
 
+    when(delegateExecution.getVariable(TOKEN_HEADER_NAME)).thenReturn(UUID);
     when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
 
     delegate.execute(delegateExecution);
@@ -254,7 +255,7 @@ class RequestDelegateTest {
 
   @Test
   void testFromTaskWorks() {
-    assertEquals(RequestTask.class, delegate.fromTask());
+    assertEquals(FolioRequestTask.class, delegate.fromTask());
   }
 
   /**
@@ -274,6 +275,7 @@ class RequestDelegateTest {
       embeddedVariable.setKey(TOKEN_HEADER_NAME);
       setField(responseEntity, "headers", httpHeaders);
 
+      when(delegateExecution.getVariable(TOKEN_HEADER_NAME)).thenReturn(UUID);
       when(httpService.exchange(anyString(), any(HttpMethod.class), any(), any())).thenReturn(responseEntity);
     }
 


### PR DESCRIPTION
Resolves [MODCAMUNDA-68](https://folio-org.atlassian.net/browse/MODCAMUNDA-68) .

Update the `RequestDelegate` to make it easier to extend.

Extend `RequestDelegate` as `FolioRequestDelagate`.

Add execution details to `FolioRequestDelagate` that includes the **FOLIO** headers.

Remove execution defailts that are no longer needed from `RequestDelegate`, such as removing the **FOLIO** headers.